### PR TITLE
Validator - check that normals are unit length

### DIFF
--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -149,19 +149,6 @@ function octDecodeWithoutNormalization(x, y, result) {
 }
 
 function octDecodeInRangeWithoutNormalization(x, y, rangeMax, result) {
-    // var range = 255.0;
-    // if (encoded.x === 0.0 && encoded.y === 0.0) {
-    //     return new Cartesian3(0.0, 0.0, 0.0);
-    // }
-    // encoded.x = encoded.x / range * 2.0 - 1.0;
-    // encoded.y = encoded.x / range * 2.0 - 1.0;
-    // var v = new Cartesian3(encoded.x, encoded.y, 1.0 - Math.abs(encoded.x) - Math.abs(encoded.y));
-    // if (v.z < 0.0) {
-    //     v.x = (1.0 - Math.abs(v.y)) * signNotZero(v.x);
-    //     v.y = (1.0 - Math.abs(v.x)) * signNotZero(v.y);
-    // }
-    // return v;
-
     result.x = CesiumMath.fromSNorm(x, rangeMax);
     result.y = CesiumMath.fromSNorm(y, rangeMax);
     result.z = 1.0 - (Math.abs(result.x) + Math.abs(result.y));
@@ -175,33 +162,3 @@ function octDecodeInRangeWithoutNormalization(x, y, rangeMax, result) {
 
     return result;
 }
-
-// function acomp(enc) {
-//     var v = new Cartesian2();
-//     var e = new Cartesian3(0,0,1);
-//     //ac.octEncodeInRange(Cartesian3.normalize(e,e), 255, v);
-//     fun(Cartesian3.normalize(e,e), 255, v);
-//     console.log(v);
-// }
-
-// function fun (vector,rangeMax,result) {
-//     result.x = vector.x / (Math.abs(vector.x) + Math.abs(vector.y) + Math.abs(vector.z));
-//         result.y = vector.y / (Math.abs(vector.x) + Math.abs(vector.y) + Math.abs(vector.z));
-//         if (vector.z < 0) {
-//             var x = result.x;
-//             var y = result.y;
-//             result.x = (1.0 - Math.abs(y)) * CesiumMath.signNotZero(x);
-//             result.y = (1.0 - Math.abs(x)) * CesiumMath.signNotZero(y);
-//         }
-
-//         result.x = CesiumMath.toSNorm(result.x, rangeMax);
-//         result.y = CesiumMath.toSNorm(result.y, rangeMax);
-
-//         return result;
-// }
-
-// function signNotZero(value) {
-//     return value >= 0.0 ? 1.0 : -1.0;
-// }
-
-

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -197,8 +197,7 @@ function octDecodeWithoutNormalization(x, y, rangeMax, result) {
     result.y = CesiumMath.fromSNorm(y, rangeMax);
     result.z = 1.0 - (Math.abs(result.x) + Math.abs(result.y));
 
-    if (result.z < 0.0)
-    {
+    if (result.z < 0.0) {
         var oldVX = result.x;
         result.x = (1.0 - Math.abs(result.y)) * CesiumMath.signNotZero(oldVX);
         result.y = (1.0 - Math.abs(oldVX)) * CesiumMath.signNotZero(result.y);

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -14,7 +14,7 @@ module.exports = {
     sphereInsideSphere : sphereInsideSphere,
     boxInsideBox : boxInsideBox,
     boxInsideSphere : boxInsideSphere,
-    octDecode : octDecode
+    octDecodeWithoutNormalization : octDecodeWithoutNormalization
 };
 
 function typeToComponentsLength(type) {
@@ -144,21 +144,64 @@ function boxInsideSphere(box, sphere) {
     return true;
 }
 
-function octDecode(encoded) {
-    var range = 255.0;
-    if (encoded.x === 0.0 && encoded.y === 0.0) {
-        return new Cartesian3(0.0, 0.0, 0.0);
-    }
-    encoded.x = encoded.x / range * 2.0 - 1.0;
-    encoded.y = encoded.x / range * 2.0 - 1.0;
-    var v = new Cartesian3(encoded.x, encoded.y, 1.0 - Math.abs(encoded.x) - Math.abs(encoded.y));
-    if (v.z < 0.0) {
-        v.x = (1.0 - Math.abs(v.y)) * signNotZero(v.x);
-        v.y = (1.0 - Math.abs(v.x)) * signNotZero(v.y);
-    }
-    return v;
+function octDecodeWithoutNormalization(x, y, result) {
+    return octDecodeInRangeWithoutNormalization(x, y, 255, result);
 }
 
-function signNotZero(value) {
-    return value >= 0.0 ? 1.0 : -1.0;
+function octDecodeInRangeWithoutNormalization(x, y, rangeMax, result) {
+    // var range = 255.0;
+    // if (encoded.x === 0.0 && encoded.y === 0.0) {
+    //     return new Cartesian3(0.0, 0.0, 0.0);
+    // }
+    // encoded.x = encoded.x / range * 2.0 - 1.0;
+    // encoded.y = encoded.x / range * 2.0 - 1.0;
+    // var v = new Cartesian3(encoded.x, encoded.y, 1.0 - Math.abs(encoded.x) - Math.abs(encoded.y));
+    // if (v.z < 0.0) {
+    //     v.x = (1.0 - Math.abs(v.y)) * signNotZero(v.x);
+    //     v.y = (1.0 - Math.abs(v.x)) * signNotZero(v.y);
+    // }
+    // return v;
+
+    result.x = CesiumMath.fromSNorm(x, rangeMax);
+    result.y = CesiumMath.fromSNorm(y, rangeMax);
+    result.z = 1.0 - (Math.abs(result.x) + Math.abs(result.y));
+
+    if (result.z < 0.0)
+    {
+        var oldVX = result.x;
+        result.x = (1.0 - Math.abs(result.y)) * CesiumMath.signNotZero(oldVX);
+        result.y = (1.0 - Math.abs(oldVX)) * CesiumMath.signNotZero(result.y);
+    }
+
+    return result;
 }
+
+// function acomp(enc) {
+//     var v = new Cartesian2();
+//     var e = new Cartesian3(0,0,1);
+//     //ac.octEncodeInRange(Cartesian3.normalize(e,e), 255, v);
+//     fun(Cartesian3.normalize(e,e), 255, v);
+//     console.log(v);
+// }
+
+// function fun (vector,rangeMax,result) {
+//     result.x = vector.x / (Math.abs(vector.x) + Math.abs(vector.y) + Math.abs(vector.z));
+//         result.y = vector.y / (Math.abs(vector.x) + Math.abs(vector.y) + Math.abs(vector.z));
+//         if (vector.z < 0) {
+//             var x = result.x;
+//             var y = result.y;
+//             result.x = (1.0 - Math.abs(y)) * CesiumMath.signNotZero(x);
+//             result.y = (1.0 - Math.abs(x)) * CesiumMath.signNotZero(y);
+//         }
+
+//         result.x = CesiumMath.toSNorm(result.x, rangeMax);
+//         result.y = CesiumMath.toSNorm(result.y, rangeMax);
+
+//         return result;
+// }
+
+// function signNotZero(value) {
+//     return value >= 0.0 ? 1.0 : -1.0;
+// }
+
+

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -192,11 +192,7 @@ function createUnitCube() {
     return cube;
 }
 
-function octDecodeWithoutNormalization(x, y, result) {
-    return octDecodeInRangeWithoutNormalization(x, y, 255, result);
-}
-
-function octDecodeInRangeWithoutNormalization(x, y, rangeMax, result) {
+function octDecodeWithoutNormalization(x, y, rangeMax, result) {
     result.x = CesiumMath.fromSNorm(x, rangeMax);
     result.y = CesiumMath.fromSNorm(y, rangeMax);
     result.z = 1.0 - (Math.abs(result.x) + Math.abs(result.y));

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -13,7 +13,8 @@ module.exports = {
     regionInsideRegion : regionInsideRegion,
     sphereInsideSphere : sphereInsideSphere,
     boxInsideBox : boxInsideBox,
-    boxInsideSphere : boxInsideSphere
+    boxInsideSphere : boxInsideSphere,
+    octDecode : octDecode
 };
 
 function typeToComponentsLength(type) {
@@ -141,4 +142,23 @@ function boxInsideSphere(box, sphere) {
         }
     }
     return true;
+}
+
+function octDecode(encoded) {
+    var range = 255.0;
+    if (encoded.x === 0.0 && encoded.y === 0.0) {
+        return new Cartesian3(0.0, 0.0, 0.0);
+    }
+    encoded.x = encoded.x / range * 2.0 - 1.0;
+    encoded.y = encoded.x / range * 2.0 - 1.0;
+    var v = new Cartesian3(encoded.x, encoded.y, 1.0 - Math.abs(encoded.x) - Math.abs(encoded.y));
+    if (v.z < 0.0) {
+        v.x = (1.0 - Math.abs(v.y)) * signNotZero(v.x);
+        v.y = (1.0 - Math.abs(v.x)) * signNotZero(v.y);
+    }
+    return v;
+}
+
+function signNotZero(value) {
+    return value >= 0.0 ? 1.0 : -1.0;
 }

--- a/validator/lib/validateI3dm.js
+++ b/validator/lib/validateI3dm.js
@@ -230,7 +230,7 @@ function validateI3dm(content) {
         normal = featureTable.getPropertyArray('NORMAL_UP_OCT32P', componentDatatype, 1);
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
-            octDecodeWithoutNormalization(normal[i], normal[i+1], normalVec);
+            octDecodeWithoutNormalization(normal[i], normal[i+1], 65536, normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
             if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_UP_OCT32P must be of length 1.0';
@@ -256,7 +256,7 @@ function validateI3dm(content) {
         normal = featureTable.getPropertyArray('NORMAL_RIGHT_OCT32P', componentDatatype, 1);
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
-            normalVec = octDecodeWithoutNormalization(normal[i], normal[i+1], normalVec);
+            normalVec = octDecodeWithoutNormalization(normal[i], normal[i+1], 65536, normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
             if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_RIGHT_OCT32P must be of length 1.0';

--- a/validator/lib/validateI3dm.js
+++ b/validator/lib/validateI3dm.js
@@ -230,7 +230,7 @@ function validateI3dm(content) {
         normal = featureTable.getPropertyArray('NORMAL_UP_OCT32P', componentDatatype, 1);
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
-            octDecodeWithoutNormalization(normal[i], normal[i+1], 65536, normalVec);
+            octDecodeWithoutNormalization(normal[i], normal[i+1], 65535, normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
             if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_UP_OCT32P must be of length 1.0';
@@ -256,7 +256,7 @@ function validateI3dm(content) {
         normal = featureTable.getPropertyArray('NORMAL_RIGHT_OCT32P', componentDatatype, 1);
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
-            normalVec = octDecodeWithoutNormalization(normal[i], normal[i+1], 65536, normalVec);
+            octDecodeWithoutNormalization(normal[i], normal[i+1], 65535, normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
             if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_RIGHT_OCT32P must be of length 1.0';

--- a/validator/lib/validateI3dm.js
+++ b/validator/lib/validateI3dm.js
@@ -14,10 +14,9 @@ var isBufferValidUtf8 = utility.isBufferValidUtf8;
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var Cartesian3 = Cesium.Cartesian3;
-var Cartesian2 = Cesium.Cartesian2;
 var Cesium3DTileFeatureTable = Cesium.Cesium3DTileFeatureTable;
 var ComponentDatatype = Cesium.ComponentDatatype;
-var octDecode = utility.octDecode;
+var octDecodeWithoutNormalization = utility.octDecodeWithoutNormalization;
 
 module.exports = validateI3dm;
 
@@ -197,7 +196,7 @@ function validateI3dm(content) {
         return 'Feature table property NORMAL_RIGHT_OCT32P is required when NORMAL_UP_OCT32P is present.';
     }
 
-    if (defined(!featureTableJson.NORMAL_UP_OCT32P) && defined(featureTableJson.NORMAL_RIGHT_OCT32P)) {
+    if (!defined(featureTableJson.NORMAL_UP_OCT32P) && defined(featureTableJson.NORMAL_RIGHT_OCT32P)) {
         return 'Feature table property NORMAL_UP_OCT32P is required when NORMAL_RIGHT_OCT32P is present.';
     }
 
@@ -205,10 +204,8 @@ function validateI3dm(content) {
         return 'Feature table properties QUANTIZED_VOLUME_OFFSET and QUANTIZED_VOLUME_SCALE are required when POSITION_QUANTIZED is present.';
     }
 
-    //normal length check
     var normal;
-    var normalVec;
-    var normalVec2;
+    var normalVec = new Cartesian3();
     var normLength;
     var magnitude;
     var componentDatatype;
@@ -223,7 +220,7 @@ function validateI3dm(content) {
         for (i = 0; i < normLength; i += 3) {
             normalVec = Cartesian3.fromElements(normal[i], normal[i+1], normal[i+2]);
             magnitude = Cartesian3.magnitude(normalVec);
-            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON4) {
+            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_UP must be of length 1.0';
             }
         }
@@ -233,10 +230,9 @@ function validateI3dm(content) {
         normal = featureTable.getPropertyArray('NORMAL_UP_OCT32P', componentDatatype, 1);
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
-            normalVec2 = Cartesian2.fromElements(normal[i], normal[i+1]);
-            normalVec = octDecode(normalVec2);
+            octDecodeWithoutNormalization(normal[i], normal[i+1], normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
-            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON4) {
+            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_UP_OCT32P must be of length 1.0';
             }
         }
@@ -250,7 +246,7 @@ function validateI3dm(content) {
         for (i = 0; i < normLength; i += 3) {
             normalVec = Cartesian3.fromElements(normal[i], normal[i+1], normal[i+2]);
             magnitude = Cartesian3.magnitude(normalVec);
-            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON4) {
+            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_RIGHT must be of length 1.0';
             }
         }
@@ -260,10 +256,9 @@ function validateI3dm(content) {
         normal = featureTable.getPropertyArray('NORMAL_RIGHT_OCT32P', componentDatatype, 1);
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
-            normalVec2 = Cartesian2.fromElements(normal[i], normal[i+1]);
-            normalVec = octDecode(normalVec2);
+            normalVec = octDecodeWithoutNormalization(normal[i], normal[i+1], normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
-            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON4) {
+            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_RIGHT_OCT32P must be of length 1.0';
             }
         }

--- a/validator/lib/validatePnts.js
+++ b/validator/lib/validatePnts.js
@@ -202,30 +202,30 @@ function validatePnts(content) {
         }
     }
 
-    var normal;
-    var normalVec = new Cartesian3();
+    var normalArray;
+    var normal = new Cartesian3();
     var normLength;
     var magnitude;
     if (defined(featureTableJson.NORMAL)) {
-        featureTable.featuresLength = pointsLength * 3;
-        componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.NORMAL.componentType, 'FLOAT', 3));
-        normal = featureTable.getPropertyArray('NORMAL', componentDatatype, 1);
-        normLength = normal.length;
+        featureTable.featuresLength = pointsLength;
+        componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.NORMAL.componentType, 'FLOAT'));
+        normalArray = featureTable.getPropertyArray('NORMAL', componentDatatype, 3);
+        normLength = normalArray.length;
         for (i = 0; i < normLength; i += 3) {
-            normalVec = Cartesian3.fromElements(normal[i], normal[i+1], normal[i+2]);
-            magnitude = Cartesian3.magnitude(normalVec);
+            Cartesian3.unpack(normalArray, i, normal);
+            magnitude = Cartesian3.magnitude(normal);
             if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL must be of length 1.0';
             }
         }
     } else if (defined(featureTableJson.NORMAL_OCT16P)) {
-        featureTable.featuresLength = pointsLength * 2;
-        componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.NORMAL_OCT16P.componentType, 'UNSIGNED_SHORT', 2));
-        normal = featureTable.getPropertyArray('NORMAL_OCT16P', componentDatatype, 1);
-        normLength = normal.length;
+        featureTable.featuresLength = pointsLength;
+        componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.NORMAL_OCT16P.componentType, 'UNSIGNED_SHORT'));
+        normalArray = featureTable.getPropertyArray('NORMAL_OCT16P', componentDatatype, 2);
+        normLength = normalArray.length;
         for (i = 0; i < normLength; i +=2 ) {
-            octDecodeWithoutNormalization(normal[i], normal[i+1], 255, normalVec);
-            magnitude = Cartesian3.magnitude(normalVec);
+            octDecodeWithoutNormalization(normalArray[i], normalArray[i+1], 255, normal);
+            magnitude = Cartesian3.magnitude(normal);
             if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_OCT16P must be of length 1.0';
             }

--- a/validator/lib/validatePnts.js
+++ b/validator/lib/validatePnts.js
@@ -9,6 +9,8 @@ var featureTableSchema = require('../specs/data/schema/featureTable.schema.json'
 
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
+var Cartesian3 = Cesium.Cartesian3;
+var Cartesian2 = Cesium.Cartesian2;
 var Cesium3DTileFeatureTable = Cesium.Cesium3DTileFeatureTable;
 var ComponentDatatype = Cesium.ComponentDatatype;
 
@@ -183,18 +185,74 @@ function validatePnts(content) {
         return 'Feature table property BATCH_LENGTH must be less than or equal to POINTS_LENGTH.';
     }
 
+    var featureTable = new Cesium3DTileFeatureTable(featureTableJson, featureTableBinary);
+    featureTable.featuresLength = pointsLength;
+
+    var i;
+    var componentDatatype;
     if (defined(featureTableJson.BATCH_ID)) {
-        var featureTable = new Cesium3DTileFeatureTable(featureTableJson, featureTableBinary);
-        featureTable.featuresLength = pointsLength;
-        var componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.BATCH_ID.componentType, 'UNSIGNED_SHORT'));
+        componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.BATCH_ID.componentType, 'UNSIGNED_SHORT'));
         var batchIds = featureTable.getPropertyArray('BATCH_ID', componentDatatype, 1);
         var length = batchIds.length;
-        for (var i = 0; i < length; i++) {
+        for (i = 0; i < length; i++) {
             if (batchIds[i] >= featureTableJson.BATCH_LENGTH) {
                 return 'All the BATCH_IDs must have values less than feature table property BATCH_LENGTH.';
             }
         }
     }
+
+    // check for unit length normal
+    var normal;
+    var normalVec;
+    var normLength;
+    var magnitude;
+    //var isOctEncoded16P = false;
+    //console.log(featureTableJson);
+    if (defined(featureTableJson.NORMAL)) {
+        featureTable.featuresLength = pointsLength * 3;
+        componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.NORMAL.componentType, 'FLOAT', 3));
+        normal = featureTable.getPropertyArray('NORMAL', componentDatatype, 1);
+        normLength = normal.length;
+        for(i=0; i<normLength; i+=3) {
+            normalVec = Cartesian3.fromElements(normal[i], normal[i+1], normal[i+2]);
+            magnitude = Cartesian3.magnitude(normalVec);
+            if(magnitude !== 1.0) {
+                return 'normal defined in NORMAL must be of length 1.0';
+            }
+        }
+    } else if (defined(featureTableJson.NORMAL_OCT16P)) {
+        featureTable.featuresLength = pointsLength * 2;
+        //isOctEncoded16P = true;
+        componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.NORMAL_OCT16P.componentType, 'UNSIGNED_SHORT', 2));
+        normal = featureTable.getPropertyArray('NORMAL_OCT16P', componentDatatype, 1);
+        //console.log(normal);
+        normLength = normal.length;
+        for(i=0; i<normLength; i+=2) {
+            normalVec = Cartesian2.fromElements(normal[i], normal[i+1]);
+            var normalVec3 = octDecode(normalVec);
+            magnitude = Cartesian3.magnitude(normalVec3);
+            if(Math.abs(1.0 - magnitude) > Cesium.Math.EPSILON4) {
+                return 'normal defined in NORMAL_OCT16P must be of length 1.0';
+            }
+        }
+    }
+
+    // if (defined(normal)) {
+    //     var normLength = normal.length;
+    //     for(i=0; i<normLength; i+=3)
+    //     {
+    //         normalVec = Cartesian3.fromElements(normal[i], normal[i+1], normal[i+2]);
+    //         var magnitude = Cartesian3.magnitude(normalVec);
+    //         console.log(normalVec);
+    //         console.log(magnitude);
+    //         if(magnitude !== 1.0) {
+    //             if (isOctEncoded16P) {
+    //                 //return 'normal defined in NORMAL_OCT16P must be of length 1.0';
+    //             }
+    //             //return 'normal defined in NORMAL must be of length 1.0';
+    //         }
+    //     }
+    // }
 
     var featureTableMessage = validateFeatureTable(featureTableSchema, featureTableJson, featureTableBinary, pointsLength, featureTableSemantics);
     if (defined(featureTableMessage)) {
@@ -205,4 +263,23 @@ function validatePnts(content) {
     if (defined(batchTableMessage)) {
         return batchTableMessage;
     }
+}
+
+function octDecode(encoded) {
+    var range = 255.0;
+    if (encoded.x === 0.0 && encoded.y === 0.0) {
+        return new Cartesian3(0.0, 0.0, 0.0);
+    }
+    encoded.x = encoded.x / range * 2.0 - 1.0;
+    encoded.y = encoded.x / range * 2.0 - 1.0;
+    var v = new Cartesian3(encoded.x, encoded.y, 1.0 - Math.abs(encoded.x) - Math.abs(encoded.y));
+    if (v.z < 0.0) {
+        v.x = (1.0 - Math.abs(v.y)) * signNotZero(v.x);
+        v.y = (1.0 - Math.abs(v.x)) * signNotZero(v.y);
+    }
+    return v;//Cartesian3.normalize(v, new Cartesian3());
+}
+
+function signNotZero(value) {
+    return value >= 0.0 ? 1.0 : -1.0;
 }

--- a/validator/lib/validatePnts.js
+++ b/validator/lib/validatePnts.js
@@ -206,53 +206,32 @@ function validatePnts(content) {
     var normalVec;
     var normLength;
     var magnitude;
-    //var isOctEncoded16P = false;
-    //console.log(featureTableJson);
     if (defined(featureTableJson.NORMAL)) {
         featureTable.featuresLength = pointsLength * 3;
         componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.NORMAL.componentType, 'FLOAT', 3));
         normal = featureTable.getPropertyArray('NORMAL', componentDatatype, 1);
         normLength = normal.length;
-        for(i=0; i<normLength; i+=3) {
+        for (i = 0; i < normLength; i += 3) {
             normalVec = Cartesian3.fromElements(normal[i], normal[i+1], normal[i+2]);
             magnitude = Cartesian3.magnitude(normalVec);
-            if(magnitude !== 1.0) {
+            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON4) {
                 return 'normal defined in NORMAL must be of length 1.0';
             }
         }
     } else if (defined(featureTableJson.NORMAL_OCT16P)) {
         featureTable.featuresLength = pointsLength * 2;
-        //isOctEncoded16P = true;
         componentDatatype = ComponentDatatype.fromName(defaultValue(featureTableJson.NORMAL_OCT16P.componentType, 'UNSIGNED_SHORT', 2));
         normal = featureTable.getPropertyArray('NORMAL_OCT16P', componentDatatype, 1);
-        //console.log(normal);
         normLength = normal.length;
-        for(i=0; i<normLength; i+=2) {
-            normalVec = Cartesian2.fromElements(normal[i], normal[i+1]);
-            var normalVec3 = octDecode(normalVec);
-            magnitude = Cartesian3.magnitude(normalVec3);
-            if(Math.abs(1.0 - magnitude) > Cesium.Math.EPSILON4) {
+        for (i = 0; i < normLength; i +=2 ) {
+            var normalVec2 = Cartesian2.fromElements(normal[i], normal[i+1]);
+            normalVec = octDecode(normalVec2);
+            magnitude = Cartesian3.magnitude(normalVec);
+            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON4) {
                 return 'normal defined in NORMAL_OCT16P must be of length 1.0';
             }
         }
     }
-
-    // if (defined(normal)) {
-    //     var normLength = normal.length;
-    //     for(i=0; i<normLength; i+=3)
-    //     {
-    //         normalVec = Cartesian3.fromElements(normal[i], normal[i+1], normal[i+2]);
-    //         var magnitude = Cartesian3.magnitude(normalVec);
-    //         console.log(normalVec);
-    //         console.log(magnitude);
-    //         if(magnitude !== 1.0) {
-    //             if (isOctEncoded16P) {
-    //                 //return 'normal defined in NORMAL_OCT16P must be of length 1.0';
-    //             }
-    //             //return 'normal defined in NORMAL must be of length 1.0';
-    //         }
-    //     }
-    // }
 
     var featureTableMessage = validateFeatureTable(featureTableSchema, featureTableJson, featureTableBinary, pointsLength, featureTableSemantics);
     if (defined(featureTableMessage)) {
@@ -277,7 +256,7 @@ function octDecode(encoded) {
         v.x = (1.0 - Math.abs(v.y)) * signNotZero(v.x);
         v.y = (1.0 - Math.abs(v.x)) * signNotZero(v.y);
     }
-    return v;//Cartesian3.normalize(v, new Cartesian3());
+    return v;
 }
 
 function signNotZero(value) {

--- a/validator/lib/validatePnts.js
+++ b/validator/lib/validatePnts.js
@@ -3,6 +3,7 @@ var Cesium = require('cesium');
 var bufferToJson = require('../lib/bufferToJson');
 var validateBatchTable = require('../lib/validateBatchTable');
 var validateFeatureTable = require('../lib/validateFeatureTable');
+var utility = require('../lib/utility');
 
 var batchTableSchema = require('../specs/data/schema/batchTable.schema.json');
 var featureTableSchema = require('../specs/data/schema/featureTable.schema.json');
@@ -13,6 +14,7 @@ var Cartesian3 = Cesium.Cartesian3;
 var Cartesian2 = Cesium.Cartesian2;
 var Cesium3DTileFeatureTable = Cesium.Cesium3DTileFeatureTable;
 var ComponentDatatype = Cesium.ComponentDatatype;
+var octDecode = utility.octDecode;
 
 module.exports = validatePnts;
 
@@ -201,7 +203,6 @@ function validatePnts(content) {
         }
     }
 
-    // check for unit length normal
     var normal;
     var normalVec;
     var normLength;
@@ -242,23 +243,4 @@ function validatePnts(content) {
     if (defined(batchTableMessage)) {
         return batchTableMessage;
     }
-}
-
-function octDecode(encoded) {
-    var range = 255.0;
-    if (encoded.x === 0.0 && encoded.y === 0.0) {
-        return new Cartesian3(0.0, 0.0, 0.0);
-    }
-    encoded.x = encoded.x / range * 2.0 - 1.0;
-    encoded.y = encoded.x / range * 2.0 - 1.0;
-    var v = new Cartesian3(encoded.x, encoded.y, 1.0 - Math.abs(encoded.x) - Math.abs(encoded.y));
-    if (v.z < 0.0) {
-        v.x = (1.0 - Math.abs(v.y)) * signNotZero(v.x);
-        v.y = (1.0 - Math.abs(v.x)) * signNotZero(v.y);
-    }
-    return v;
-}
-
-function signNotZero(value) {
-    return value >= 0.0 ? 1.0 : -1.0;
 }

--- a/validator/lib/validatePnts.js
+++ b/validator/lib/validatePnts.js
@@ -225,7 +225,6 @@ function validatePnts(content) {
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
             octDecodeWithoutNormalization(normal[i], normal[i+1], normalVec);
-            //console.log(normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
             if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_OCT16P must be of length 1.0';

--- a/validator/lib/validatePnts.js
+++ b/validator/lib/validatePnts.js
@@ -224,7 +224,7 @@ function validatePnts(content) {
         normal = featureTable.getPropertyArray('NORMAL_OCT16P', componentDatatype, 1);
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
-            octDecodeWithoutNormalization(normal[i], normal[i+1], normalVec);
+            octDecodeWithoutNormalization(normal[i], normal[i+1], 255, normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
             if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_OCT16P must be of length 1.0';

--- a/validator/lib/validatePnts.js
+++ b/validator/lib/validatePnts.js
@@ -11,10 +11,9 @@ var featureTableSchema = require('../specs/data/schema/featureTable.schema.json'
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var Cartesian3 = Cesium.Cartesian3;
-var Cartesian2 = Cesium.Cartesian2;
 var Cesium3DTileFeatureTable = Cesium.Cesium3DTileFeatureTable;
 var ComponentDatatype = Cesium.ComponentDatatype;
-var octDecode = utility.octDecode;
+var octDecodeWithoutNormalization = utility.octDecodeWithoutNormalization;
 
 module.exports = validatePnts;
 
@@ -204,7 +203,7 @@ function validatePnts(content) {
     }
 
     var normal;
-    var normalVec;
+    var normalVec = new Cartesian3();
     var normLength;
     var magnitude;
     if (defined(featureTableJson.NORMAL)) {
@@ -215,7 +214,7 @@ function validatePnts(content) {
         for (i = 0; i < normLength; i += 3) {
             normalVec = Cartesian3.fromElements(normal[i], normal[i+1], normal[i+2]);
             magnitude = Cartesian3.magnitude(normalVec);
-            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON4) {
+            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL must be of length 1.0';
             }
         }
@@ -225,10 +224,10 @@ function validatePnts(content) {
         normal = featureTable.getPropertyArray('NORMAL_OCT16P', componentDatatype, 1);
         normLength = normal.length;
         for (i = 0; i < normLength; i +=2 ) {
-            var normalVec2 = Cartesian2.fromElements(normal[i], normal[i+1]);
-            normalVec = octDecode(normalVec2);
+            octDecodeWithoutNormalization(normal[i], normal[i+1], normalVec);
+            //console.log(normalVec);
             magnitude = Cartesian3.magnitude(normalVec);
-            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON4) {
+            if (Math.abs(magnitude - 1.0) > Cesium.Math.EPSILON2) {
                 return 'normal defined in NORMAL_OCT16P must be of length 1.0';
             }
         }

--- a/validator/specs/lib/validateI3dmSpec.js
+++ b/validator/specs/lib/validateI3dmSpec.js
@@ -254,31 +254,7 @@ describe('validate i3dm', function() {
         expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_UP must be of length 1.0');
     });
 
-    it('succeeds for normals with unit length when NORMAL_UP is defined', function() {
-        var i3dm = createI3dm({
-            featureTableJson : {
-                INSTANCES_LENGTH : 4,
-                POSITION : [
-                    0, 0, 0,
-                    1, 0, 0,
-                    0, 0, 1,
-                    0, 1, 0],
-                NORMAL_UP : [
-                    0, 1, 0,
-                    0, 1, 0,
-                    0, 1, 0,
-                    0, 1, 0],
-                NORMAL_RIGHT : [
-                    1, 0, 0,
-                    1, 0, 0,
-                    1, 0, 0,
-                    1, 0, 0]
-            }
-        });
-        expect(validateI3dm(i3dm)).toBeUndefined();
-    });
-
-        it('returns error message for normals with non-unit length when NORMAL_RIGHT is defined [Test using feature table JSON]', function() {
+    it('returns error message for normals with non-unit length when NORMAL_RIGHT is defined [Test using feature table JSON]', function() {
         var i3dm = createI3dm({
             featureTableJson : {
                 INSTANCES_LENGTH : 4,
@@ -349,7 +325,7 @@ describe('validate i3dm', function() {
         expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_RIGHT must be of length 1.0');
     });
 
-    it('succeeds for normals with unit length when NORMAL_RIGHT is defined', function() {
+    it('succeeds for normals with unit length when NORMAL_UP and NORMAL_RIGHT are defined', function() {
         var i3dm = createI3dm({
             featureTableJson : {
                 INSTANCES_LENGTH : 4,
@@ -368,6 +344,173 @@ describe('validate i3dm', function() {
                     1, 0, 0,
                     1, 0, 0,
                     1, 0, 0]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBeUndefined();
+    });
+
+    // OCT
+    it('returns error message for normals with non-unit length when NORMAL_UP_OCT32P is defined [Test using feature table JSON]', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP_OCT32P : [
+                    128, 255,
+                    128, 255,
+                    128, 255,
+                    191, 191],
+                NORMAL_RIGHT_OCT32P : [
+                    255, 128,
+                    255, 128,
+                    255, 128,
+                    255, 128]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_UP_OCT32P must be of length 1.0');
+    });
+
+    it('returns error message for normals with non-unit length when NORMAL_UP_OCT32P is defined [Test using feature table Binary]', function() {
+        var positionArray = new Float32Array([
+            0, 0, 0,
+            1, 0, 0,
+            0, 0, 1,
+            0, 1, 0
+        ]);
+        var positionBinary = Buffer.from(positionArray.buffer);
+
+        var normalUpArray = new Uint8Array([
+            128, 255,
+            128, 255,
+            128, 255,
+            191, 191
+        ]);
+        var normalUpBinary = Buffer.from(normalUpArray.buffer);
+
+        var normalRightArray = new Uint8Array([
+            255, 128,
+            255, 128,
+            255, 128,
+            255, 128
+        ]);
+        var normalRightBinary = Buffer.from(normalRightArray.buffer);
+
+        var combinedBinary = Buffer.concat([positionBinary, normalUpBinary, normalRightBinary]);
+
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : {
+                    byteOffset : 0
+                },
+                NORMAL_UP_OCT32P : {
+                    byteOffset : 48,
+                    componentType : 'UNSIGNED_BYTE'
+                },
+                NORMAL_RIGHT_OCT32P : {
+                    byteOffset : 56,
+                    componentType : 'UNSIGNED_BYTE'
+                }
+            },
+            featureTableBinary : combinedBinary
+        });
+        expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_UP_OCT32P must be of length 1.0');
+    });
+
+    it('returns error message for normals with non-unit length when NORMAL_RIGHT_OCT32P is defined [Test using feature table JSON]', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP_OCT32P : [
+                    128, 255,
+                    128, 255,
+                    128, 255,
+                    128, 255],
+                NORMAL_RIGHT_OCT32P : [
+                    191, 191,
+                    255, 128,
+                    255, 128,
+                    255, 128]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_RIGHT_OCT32P must be of length 1.0');
+    });
+
+    it('returns error message for normals with non-unit length when NORMAL_RIGHT_OCT32P is defined [Test using feature table Binary]', function() {
+        var positionArray = new Float32Array([
+            0, 0, 0,
+            1, 0, 0,
+            0, 0, 1,
+            0, 1, 0
+        ]);
+        var positionBinary = Buffer.from(positionArray.buffer);
+
+        var normalUpArray = new Uint8Array([
+            128, 255,
+            128, 255,
+            128, 255,
+            128, 255
+        ]);
+        var normalUpBinary = Buffer.from(normalUpArray.buffer);
+
+        var normalRightArray = new Uint8Array([
+            255, 128,
+            255, 128,
+            255, 128,
+            191, 191
+        ]);
+        var normalRightBinary = Buffer.from(normalRightArray.buffer);
+
+        var combinedBinary = Buffer.concat([positionBinary, normalUpBinary, normalRightBinary]);
+
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : {
+                    byteOffset : 0
+                },
+                NORMAL_UP_OCT32P : {
+                    byteOffset : 48,
+                    componentType : 'UNSIGNED_BYTE'
+                },
+                NORMAL_RIGHT_OCT32P : {
+                    byteOffset : 56,
+                    componentType : 'UNSIGNED_BYTE'
+                }
+            },
+            featureTableBinary : combinedBinary
+        });
+        expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_RIGHT_OCT32P must be of length 1.0');
+    });
+
+    it('succeeds for normals with unit length when NORMAL_UP_OCT32P and NORMAL_RIGHT_OCT32P are defined', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP_OCT32P : [
+                    128, 255,
+                    128, 255,
+                    128, 255,
+                    128, 255],
+                NORMAL_RIGHT_OCT32P : [
+                    255, 128,
+                    255, 128,
+                    255, 128,
+                    255, 128]
             }
         });
         expect(validateI3dm(i3dm)).toBeUndefined();

--- a/validator/specs/lib/validateI3dmSpec.js
+++ b/validator/specs/lib/validateI3dmSpec.js
@@ -182,6 +182,197 @@ describe('validate i3dm', function() {
         expect(validateI3dm(i3dm)).toBe('Batch table binary property "height" exceeds batch table binary byte length.');
     });
 
+    //normal length check
+    it('returns error message for normals with non-unit length when NORMAL_UP is defined [Test using feature table JSON]', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP : [
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 2, 0],
+                NORMAL_RIGHT : [
+                    1, 0, 0,
+                    1, 0, 0,
+                    1, 0, 0,
+                    1, 0, 0]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_UP must be of length 1.0');
+    });
+
+    it('returns error message for normals with non-unit length when NORMAL_UP is defined [Test using feature table Binary]', function() {
+        var positionArray = new Float32Array([
+            0, 0, 0,
+            1, 0, 0,
+            0, 0, 1,
+            0, 1, 0
+        ]);
+        var positionBinary = Buffer.from(positionArray.buffer);
+
+        var normalUpArray = new Float32Array([
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0,
+            0, 2, 0
+        ]);
+        var normalUpBinary = Buffer.from(normalUpArray.buffer);
+
+        var normalRightArray = new Float32Array([
+            1, 0, 0,
+            1, 0, 0,
+            1, 0, 0,
+            1, 0, 0
+        ]);
+        var normalRightBinary = Buffer.from(normalRightArray.buffer);
+
+        var combinedBinary = Buffer.concat([positionBinary, normalUpBinary, normalRightBinary]);
+
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : {
+                    byteOffset : 0
+                },
+                NORMAL_UP : {
+                    byteOffset : 48,
+                    componentType : 'FLOAT'
+                },
+                NORMAL_RIGHT : {
+                    byteOffset : 96,
+                    componentType : 'FLOAT'
+                }
+            },
+            featureTableBinary : combinedBinary
+        });
+        expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_UP must be of length 1.0');
+    });
+
+    it('succeeds for normals with unit length when NORMAL_UP is defined', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP : [
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0],
+                NORMAL_RIGHT : [
+                    1, 0, 0,
+                    1, 0, 0,
+                    1, 0, 0,
+                    1, 0, 0]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBeUndefined();
+    });
+
+        it('returns error message for normals with non-unit length when NORMAL_RIGHT is defined [Test using feature table JSON]', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP : [
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0],
+                NORMAL_RIGHT : [
+                    1, 0, 0,
+                    1, 0, 0,
+                    1, 0, 0,
+                    2, 0, 0]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_RIGHT must be of length 1.0');
+    });
+
+    it('returns error message for normals with non-unit length when NORMAL_RIGHT is defined [Test using feature table Binary]', function() {
+        var positionArray = new Float32Array([
+            0, 0, 0,
+            1, 0, 0,
+            0, 0, 1,
+            0, 1, 0
+        ]);
+        var positionBinary = Buffer.from(positionArray.buffer);
+
+        var normalUpArray = new Float32Array([
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0
+        ]);
+        var normalUpBinary = Buffer.from(normalUpArray.buffer);
+
+        var normalRightArray = new Float32Array([
+            1, 0, 0,
+            1, 0, 0,
+            1, 0, 0,
+            2, 0, 0
+        ]);
+        var normalRightBinary = Buffer.from(normalRightArray.buffer);
+
+        var combinedBinary = Buffer.concat([positionBinary, normalUpBinary, normalRightBinary]);
+
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : {
+                    byteOffset : 0
+                },
+                NORMAL_UP : {
+                    byteOffset : 48,
+                    componentType : 'FLOAT'
+                },
+                NORMAL_RIGHT : {
+                    byteOffset : 96,
+                    componentType : 'FLOAT'
+                }
+            },
+            featureTableBinary : combinedBinary
+        });
+        expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_RIGHT must be of length 1.0');
+    });
+
+    it('succeeds for normals with unit length when NORMAL_RIGHT is defined', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP : [
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0],
+                NORMAL_RIGHT : [
+                    1, 0, 0,
+                    1, 0, 0,
+                    1, 0, 0,
+                    1, 0, 0]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBeUndefined();
+    });
+
     it('succeeds for valid i3dm', function() {
         var i3dm = createI3dm({
             featureTableJson : {

--- a/validator/specs/lib/validateI3dmSpec.js
+++ b/validator/specs/lib/validateI3dmSpec.js
@@ -510,6 +510,54 @@ describe('validate i3dm', function() {
         expect(validateI3dm(i3dm)).toBeUndefined();
     });
 
+    it('returns error message when NORMAL_UP and NORMAL_RIGHT are not mutually orthogonal', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP : [
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0,
+                    0, 1, 0],
+                NORMAL_RIGHT : [
+                    1, 0, 0,
+                    1, 0, 0,
+                    1, 0, 0,
+                    0, 1, 0]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBe('up and right normals must be mutually orthogonal');
+    });
+
+    it('returns error message when NORMAL_UP_OCT32P and NORMAL_RIGHT_OCT32P are not mutually orthogonal', function() {
+        var i3dm = createI3dm({
+            featureTableJson : {
+                INSTANCES_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL_UP_OCT32P : [
+                    32768, 65535,
+                    32768, 65535,
+                    32768, 65535,
+                    32768, 65535],
+                NORMAL_RIGHT_OCT32P : [
+                    65535, 32768,
+                    65535, 32768,
+                    65535, 32768,
+                    32768, 65535]
+            }
+        });
+        expect(validateI3dm(i3dm)).toBe('up and right normals must be mutually orthogonal');
+    });
+
     it('succeeds for valid i3dm', function() {
         var i3dm = createI3dm({
             featureTableJson : {

--- a/validator/specs/lib/validateI3dmSpec.js
+++ b/validator/specs/lib/validateI3dmSpec.js
@@ -358,15 +358,15 @@ describe('validate i3dm', function() {
                     0, 0, 1,
                     0, 1, 0],
                 NORMAL_UP_OCT32P : [
-                    128, 255,
-                    128, 255,
-                    128, 255,
-                    191, 191],
+                    32768, 65535,
+                    32768, 65535,
+                    32768, 65535,
+                    49151, 49151],
                 NORMAL_RIGHT_OCT32P : [
-                    255, 128,
-                    255, 128,
-                    255, 128,
-                    255, 128]
+                    65535, 32768,
+                    65535, 32768,
+                    65535, 32768,
+                    65535, 32768]
             }
         });
         expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_UP_OCT32P must be of length 1.0');
@@ -381,19 +381,19 @@ describe('validate i3dm', function() {
         ]);
         var positionBinary = Buffer.from(positionArray.buffer);
 
-        var normalUpArray = new Uint8Array([
-            128, 255,
-            128, 255,
-            128, 255,
-            191, 191
+        var normalUpArray = new Uint16Array([
+            32768, 65535,
+            32768, 65535,
+            32768, 65535,
+            49151, 49151
         ]);
         var normalUpBinary = Buffer.from(normalUpArray.buffer);
 
-        var normalRightArray = new Uint8Array([
-            255, 128,
-            255, 128,
-            255, 128,
-            255, 128
+        var normalRightArray = new Uint16Array([
+            65535, 32768,
+            65535, 32768,
+            65535, 32768,
+            65535, 32768
         ]);
         var normalRightBinary = Buffer.from(normalRightArray.buffer);
 
@@ -406,12 +406,10 @@ describe('validate i3dm', function() {
                     byteOffset : 0
                 },
                 NORMAL_UP_OCT32P : {
-                    byteOffset : 48,
-                    componentType : 'UNSIGNED_BYTE'
+                    byteOffset : 48
                 },
                 NORMAL_RIGHT_OCT32P : {
-                    byteOffset : 56,
-                    componentType : 'UNSIGNED_BYTE'
+                    byteOffset : 64
                 }
             },
             featureTableBinary : combinedBinary
@@ -429,15 +427,15 @@ describe('validate i3dm', function() {
                     0, 0, 1,
                     0, 1, 0],
                 NORMAL_UP_OCT32P : [
-                    128, 255,
-                    128, 255,
-                    128, 255,
-                    128, 255],
+                    32768, 65535,
+                    32768, 65535,
+                    32768, 65535,
+                    32768, 65535],
                 NORMAL_RIGHT_OCT32P : [
-                    191, 191,
-                    255, 128,
-                    255, 128,
-                    255, 128]
+                    49151, 49151,
+                    65535, 32768,
+                    65535, 32768,
+                    65535, 32768]
             }
         });
         expect(validateI3dm(i3dm)).toBe('normal defined in NORMAL_RIGHT_OCT32P must be of length 1.0');
@@ -452,19 +450,19 @@ describe('validate i3dm', function() {
         ]);
         var positionBinary = Buffer.from(positionArray.buffer);
 
-        var normalUpArray = new Uint8Array([
-            128, 255,
-            128, 255,
-            128, 255,
-            128, 255
+        var normalUpArray = new Uint16Array([
+            32768, 65535,
+            32768, 65535,
+            32768, 65535,
+            32768, 65535
         ]);
         var normalUpBinary = Buffer.from(normalUpArray.buffer);
 
-        var normalRightArray = new Uint8Array([
-            255, 128,
-            255, 128,
-            255, 128,
-            191, 191
+        var normalRightArray = new Uint16Array([
+            65535, 32768,
+            65535, 32768,
+            65535, 32768,
+            49151, 49151
         ]);
         var normalRightBinary = Buffer.from(normalRightArray.buffer);
 
@@ -477,12 +475,10 @@ describe('validate i3dm', function() {
                     byteOffset : 0
                 },
                 NORMAL_UP_OCT32P : {
-                    byteOffset : 48,
-                    componentType : 'UNSIGNED_BYTE'
+                    byteOffset : 48
                 },
                 NORMAL_RIGHT_OCT32P : {
-                    byteOffset : 56,
-                    componentType : 'UNSIGNED_BYTE'
+                    byteOffset : 64
                 }
             },
             featureTableBinary : combinedBinary
@@ -500,15 +496,15 @@ describe('validate i3dm', function() {
                     0, 0, 1,
                     0, 1, 0],
                 NORMAL_UP_OCT32P : [
-                    128, 255,
-                    128, 255,
-                    128, 255,
-                    128, 255],
+                    32768, 65535,
+                    32768, 65535,
+                    32768, 65535,
+                    32768, 65535],
                 NORMAL_RIGHT_OCT32P : [
-                    255, 128,
-                    255, 128,
-                    255, 128,
-                    255, 128]
+                    65535, 32768,
+                    65535, 32768,
+                    65535, 32768,
+                    65535, 32768]
             }
         });
         expect(validateI3dm(i3dm)).toBeUndefined();

--- a/validator/specs/lib/validateI3dmSpec.js
+++ b/validator/specs/lib/validateI3dmSpec.js
@@ -182,7 +182,6 @@ describe('validate i3dm', function() {
         expect(validateI3dm(i3dm)).toBe('Batch table binary property "height" exceeds batch table binary byte length.');
     });
 
-    //normal length check
     it('returns error message for normals with non-unit length when NORMAL_UP is defined [Test using feature table JSON]', function() {
         var i3dm = createI3dm({
             featureTableJson : {
@@ -349,7 +348,6 @@ describe('validate i3dm', function() {
         expect(validateI3dm(i3dm)).toBeUndefined();
     });
 
-    // OCT
     it('returns error message for normals with non-unit length when NORMAL_UP_OCT32P is defined [Test using feature table JSON]', function() {
         var i3dm = createI3dm({
             featureTableJson : {

--- a/validator/specs/lib/validatePntsSpec.js
+++ b/validator/specs/lib/validatePntsSpec.js
@@ -212,7 +212,6 @@ describe('validate pnts', function() {
         expect(validatePnts(pnts)).toBe('Batch table binary property "height" exceeds batch table binary byte length.');
     });
 
-    // test for pnts with normal
     it('returns error message for normals with non-unit length when NORMAL is defined [Test using feature table JSON]', function() {
         var pnts = createPnts({
             featureTableJson : {

--- a/validator/specs/lib/validatePntsSpec.js
+++ b/validator/specs/lib/validatePntsSpec.js
@@ -296,10 +296,10 @@ describe('validate pnts', function() {
                     0, 0, 1,
                     1, 0, 1],
                 NORMAL_OCT16P : [
-                    128, 255,
-                    128, 255,
-                    128, 255,
-                    255, 255]
+                    191, 191,
+                    191, 191,
+                    191, 191,
+                    191, 191]
             }
         });
         expect(validatePnts(pnts)).toBe('normal defined in NORMAL_OCT16P must be of length 1.0');
@@ -315,10 +315,10 @@ describe('validate pnts', function() {
         var positionBinary = Buffer.from(positionArray.buffer);
 
         var normalOct16PArray = new Uint8Array([
-            128, 255,
-            128, 255,
-            128, 255,
-            255, 255
+            191, 191,
+            191, 191,
+            191, 191,
+            191, 191
         ]);
         var normalOct16PBinary = Buffer.from(normalOct16PArray.buffer);
 
@@ -351,8 +351,8 @@ describe('validate pnts', function() {
                     1, 0, 1],
                 NORMAL_OCT16P : [
                     128, 255,
-                    128, 255,
-                    128, 255,
+                    255, 128,
+                    128, 128,
                     128, 255]
             }
         });

--- a/validator/specs/lib/validatePntsSpec.js
+++ b/validator/specs/lib/validatePntsSpec.js
@@ -212,6 +212,153 @@ describe('validate pnts', function() {
         expect(validatePnts(pnts)).toBe('Batch table binary property "height" exceeds batch table binary byte length.');
     });
 
+    // test for pnts with normal
+    it('returns error for normals with non-unit length when NORMAL is defined [Test using feature table JSON]', function() {
+        var pnts = createPnts({
+            featureTableJson : {
+                POINTS_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL : [
+                    0, 1, 0,
+                    0, 0, 1,
+                    1, 0, 0,
+                    0, 2, 0]
+            }
+        });
+        expect(validatePnts(pnts)).toBe('normal defined in NORMAL must be of length 1.0');
+    });
+
+    it('returns error for normals with non-unit length when NORMAL is defined [Test using feature table Binary]', function() {
+        var positionArray = new Float32Array([
+            0, 0, 0,
+            1, 0, 0,
+            0, 0, 1,
+            0, 1, 0
+        ]);
+        var positionBinary = Buffer.from(positionArray.buffer);
+
+        var normalArray = new Float32Array([
+            0, 1, 0,
+            0, 0, 1,
+            1, 0, 0,
+            0, 2, 0
+        ]);
+        var normalBinary = Buffer.from(normalArray.buffer);
+
+        var combinedBinary = Buffer.concat([positionBinary, normalBinary]);
+
+        var pnts = createPnts({
+            featureTableJson : {
+                POINTS_LENGTH : 4,
+                POSITION : {
+                    byteOffset : 0
+                },
+                NORMAL : {
+                    byteOffset : 48,
+                    componentType : 'FLOAT'
+                }
+            },
+            featureTableBinary : combinedBinary
+        });
+        expect(validatePnts(pnts)).toBe('normal defined in NORMAL must be of length 1.0');
+    });
+
+    it('succeeds for normals with unit length when NORMAL is defined', function() {
+        var pnts = createPnts({
+            featureTableJson : {
+                POINTS_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    0, 1, 0],
+                NORMAL : [
+                    0, 1, 0,
+                    0, 0, 1,
+                    1, 0, 0,
+                    0, 1, 0]
+            }
+        });
+        expect(validatePnts(pnts)).toBeUndefined();
+    });
+
+    it('returns error for normals with non-unit length when NORMAL_OCT16P is defined [Test using feature table JSON]', function() {
+        var pnts = createPnts({
+            featureTableJson : {
+                POINTS_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    1, 0, 1],
+                NORMAL_OCT16P : [
+                    128, 255,
+                    128, 255,
+                    128, 255,
+                    255, 255]
+            }
+        });
+        expect(validatePnts(pnts)).toBe('normal defined in NORMAL_OCT16P must be of length 1.0');
+    });
+
+    it('returns error for normals with non-unit length when NORMAL_OCT16P is defined [Test using feature table Binary]', function() {
+        var positionArray = new Float32Array([
+            0, 0, 0,
+            65535, 0, 0,
+            0, 0, 65535,
+            65535, 0, 65535
+        ]);
+        var positionBinary = Buffer.from(positionArray.buffer);
+
+        var normalOct16PArray = new Uint8Array([
+            128, 255,
+            128, 255,
+            128, 255,
+            255, 255
+        ]);
+        var normalOct16PBinary = Buffer.from(normalOct16PArray.buffer);
+
+        var combinedBinary = Buffer.concat([positionBinary, normalOct16PBinary]);
+
+        var pnts = createPnts({
+            featureTableJson : {
+                POINTS_LENGTH : 4,
+                POSITION : {
+                    byteOffset : 0
+                },
+                NORMAL_OCT16P : {
+                    byteOffset : 48,
+                    componentType : 'UNSIGNED_BYTE'
+                }
+            },
+            featureTableBinary : combinedBinary
+        });
+        expect(validatePnts(pnts)).toBe('normal defined in NORMAL_OCT16P must be of length 1.0');
+    });
+
+    it('succeeds for normals with unit length when NORMAL_OCT16P is defined', function() {
+        var pnts = createPnts({
+            featureTableJson : {
+                POINTS_LENGTH : 4,
+                POSITION : [
+                    0, 0, 0,
+                    1, 0, 0,
+                    0, 0, 1,
+                    1, 0, 1],
+                NORMAL_OCT16P : [
+                    128, 255,
+                    128, 255,
+                    128, 255,
+                    128, 255]
+            }
+        });
+        expect(validatePnts(pnts)).toBeUndefined();
+    });
+
     it('succeeds for valid pnts', function() {
         var pnts = createPnts({
             featureTableJson : {

--- a/validator/specs/lib/validatePntsSpec.js
+++ b/validator/specs/lib/validatePntsSpec.js
@@ -213,7 +213,7 @@ describe('validate pnts', function() {
     });
 
     // test for pnts with normal
-    it('returns error for normals with non-unit length when NORMAL is defined [Test using feature table JSON]', function() {
+    it('returns error message for normals with non-unit length when NORMAL is defined [Test using feature table JSON]', function() {
         var pnts = createPnts({
             featureTableJson : {
                 POINTS_LENGTH : 4,
@@ -232,7 +232,7 @@ describe('validate pnts', function() {
         expect(validatePnts(pnts)).toBe('normal defined in NORMAL must be of length 1.0');
     });
 
-    it('returns error for normals with non-unit length when NORMAL is defined [Test using feature table Binary]', function() {
+    it('returns error message for normals with non-unit length when NORMAL is defined [Test using feature table Binary]', function() {
         var positionArray = new Float32Array([
             0, 0, 0,
             1, 0, 0,
@@ -286,7 +286,7 @@ describe('validate pnts', function() {
         expect(validatePnts(pnts)).toBeUndefined();
     });
 
-    it('returns error for normals with non-unit length when NORMAL_OCT16P is defined [Test using feature table JSON]', function() {
+    it('returns error message for normals with non-unit length when NORMAL_OCT16P is defined [Test using feature table JSON]', function() {
         var pnts = createPnts({
             featureTableJson : {
                 POINTS_LENGTH : 4,
@@ -305,7 +305,7 @@ describe('validate pnts', function() {
         expect(validatePnts(pnts)).toBe('normal defined in NORMAL_OCT16P must be of length 1.0');
     });
 
-    it('returns error for normals with non-unit length when NORMAL_OCT16P is defined [Test using feature table Binary]', function() {
+    it('returns error message for normals with non-unit length when NORMAL_OCT16P is defined [Test using feature table Binary]', function() {
         var positionArray = new Float32Array([
             0, 0, 0,
             1, 0, 0,

--- a/validator/specs/lib/validatePntsSpec.js
+++ b/validator/specs/lib/validatePntsSpec.js
@@ -308,9 +308,9 @@ describe('validate pnts', function() {
     it('returns error for normals with non-unit length when NORMAL_OCT16P is defined [Test using feature table Binary]', function() {
         var positionArray = new Float32Array([
             0, 0, 0,
-            65535, 0, 0,
-            0, 0, 65535,
-            65535, 0, 65535
+            1, 0, 0,
+            0, 0, 1,
+            1, 0, 1
         ]);
         var positionBinary = Buffer.from(positionArray.buffer);
 


### PR DESCRIPTION
Fixes #112 

Checks that normals are of unit length for i3dm and pnts.
Also checks that normal up and normal right are orthogonal for i3dm.

Created a helper function in utility.js for converting an oct-encoded vector to Catresian3, like cesium's [`AttributeCompression.octDecodeInRange`](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/AttributeCompression.js#L96), but without normalization. 