### PR TITLE
Check for overlapping Binaries in featureTableJson

### DIFF
--- a/validator/lib/validateFeatureTable.js
+++ b/validator/lib/validateFeatureTable.js
@@ -101,13 +101,13 @@ function checkPropertyOverlapping(featureTableJson, featureTableBinary, features
     }
     var count = 0;
     var arrayOfProperties = [];
-    var returnMessage = undefined;
+    var message = undefined;
     
     for (var name in featureTableJson) {
         var property = featureTableJson[name];
         var definition = featureTableSemantics[name];
         if (!defined(definition)) {
-            return returnMessage;
+            return message;
         }
         var byteOffset = property.byteOffset;
         var componentType = defaultValue(property.componentType, definition.componentType);
@@ -119,10 +119,7 @@ function checkPropertyOverlapping(featureTableJson, featureTableBinary, features
         var propertyByteLength = componentsLength * componentByteLength * itemsLength;
 
         if (defined(byteOffset)) {
-            var newProperty = new PropertyInfo(name, 1, 1, 1);
-            newProperty.currentByteOffset = byteOffset;
-            newProperty.totalOccupiedBytes = propertyByteLength;
-            newProperty.nextByteOffset = byteOffset + propertyByteLength;
+            var newProperty = new PropertyInfo(name, byteOffset, propertyByteLength, byteOffset + propertyByteLength);
             arrayOfProperties.push(newProperty);
         }
         count++;
@@ -130,17 +127,17 @@ function checkPropertyOverlapping(featureTableJson, featureTableBinary, features
 
     // Return if only one property
     if (count == 1) {
-        return returnMessage;
+        return message;
     }
 
     // Check overlap
     for (var i = 0; i < arrayOfProperties.length; ++i) {
-        returnMessage = checkOverlap(arrayOfProperties, i);
-        if(defined(returnMessage)) {
+        message = checkOverlap(arrayOfProperties, i);
+        if (defined(message)) {
             break;
         }
     }
-    return returnMessage;
+    return message;
 }
 
 function checkOverlap(arrayOfProperties, index) {

--- a/validator/lib/validateFeatureTable.js
+++ b/validator/lib/validateFeatureTable.js
@@ -118,16 +118,6 @@ function checkPropertyOverlapping(featureTableJson, featureTableBinary, features
         var itemsLength = definition.global ? 1 : featuresLength;
         var propertyByteLength = componentsLength * componentByteLength * itemsLength;
 
-        // console.log('name: ' + name);
-        // console.log('byte offset: ' + byteOffset);
-        // console.log('componentType: ' + componentType);
-        // console.log('type: ' + type);
-        // console.log('componentsLength: ' + componentsLength);
-        // console.log('componentByteLength: ' + componentByteLength)
-        // console.log('itemsLength: ' + itemsLength)
-        // console.log('propertyByteLength: ' + propertyByteLength)
-        // console.log('');
-
         if (defined(byteOffset)) {
             var newProperty = new PropertyInfo(name, 1, 1, 1);
             newProperty.currentByteOffset = byteOffset;
@@ -144,11 +134,35 @@ function checkPropertyOverlapping(featureTableJson, featureTableBinary, features
     }
 
     // Check overlap
-    for (var i = 0; i < (arrayOfProperties.length - 1); ++i) {
-        if (arrayOfProperties[i].nextByteOffset > arrayOfProperties[i+1].currentByteOffset) {
-            returnMessage = 'binary of property \"' + arrayOfProperties[i].propertyName + '\" overlapps with \"' + arrayOfProperties[i+1].propertyName + '\".';
-            return returnMessage;
+    for (var i = 0; i < arrayOfProperties.length; ++i) {
+        returnMessage = checkOverlap(arrayOfProperties, i);
+        if(defined(returnMessage)) {
+            break;
         }
     }
     return returnMessage;
+}
+
+function checkOverlap(arrayOfProperties, index) {
+    var tempPropertyName = arrayOfProperties[index].propertyName;
+    var tempCurrentByteOffset = arrayOfProperties[index].currentByteOffset;
+    var tempNextByteOffset = arrayOfProperties[index].nextByteOffset;
+    var message = undefined;
+
+    for(var i = 0; i < arrayOfProperties.length; ++i) {
+        if (i == index) {
+            continue;
+        }
+        if (tempCurrentByteOffset < arrayOfProperties[i].currentByteOffset && tempNextByteOffset > arrayOfProperties[i].currentByteOffset) {
+            message = 'binary of property \"' + tempPropertyName + '\" overlapps with \"' + arrayOfProperties[i].propertyName + '\".';
+            break;
+        } else if (tempCurrentByteOffset > arrayOfProperties[i].currentByteOffset && tempCurrentByteOffset < arrayOfProperties[i].nextByteOffset) {
+            message = 'binary of property \"' + tempPropertyName + '\" overlapps with \"' + arrayOfProperties[i].propertyName + '\".';
+            break;
+        } else if (tempCurrentByteOffset == arrayOfProperties[i].currentByteOffset) {
+            message = 'binary of property \"' + tempPropertyName + '\" overlapps with \"' + arrayOfProperties[i].propertyName + '\".';
+            break;
+        }
+    }
+    return message;
 }

--- a/validator/specs/lib/validateFeatureTableSpec.js
+++ b/validator/specs/lib/validateFeatureTableSpec.js
@@ -41,6 +41,54 @@ var featureTableSemantics = {
 };
 
 describe('validate feature table', function() {
+    it('returns errror message when featuretable property have overlapping binaries', function() {
+        var featureTableJson = {
+            POSITION : {
+                byteOffset : 0
+            },
+            NORMAL_UP_OCT32P : {
+                byteOffset : 23
+            },
+            SCALE : {
+                byteOffset : 32
+            },
+            BATCH_ID : {
+                byteOffset : 40
+            },
+            BATCH_LENGTH : 2,
+            RTC_CENTER : [0, 0, 0],
+            EAST_NORTH_UP : true
+        };
+        var featureTableBinary = Buffer.alloc(44);
+        var featuresLength = 2;
+        var message = validateFeatureTable(featureTableSchema, featureTableJson, featureTableBinary, featuresLength, featureTableSemantics);
+        expect(message).toBeDefined();
+    });
+
+    it('succeeds when featuretable property do not have overlapping binaries', function() {
+        var featureTableJson = {
+            POSITION : {
+                byteOffset : 0
+            },
+            NORMAL_UP_OCT32P : {
+                byteOffset : 24
+            },
+            SCALE : {
+                byteOffset : 32
+            },
+            BATCH_ID : {
+                byteOffset : 40
+            },
+            BATCH_LENGTH : 2,
+            RTC_CENTER : [0, 0, 0],
+            EAST_NORTH_UP : true
+        };
+        var featureTableBinary = Buffer.alloc(44);
+        var featuresLength = 2;
+        var message = validateFeatureTable(featureTableSchema, featureTableJson, featureTableBinary, featuresLength, featureTableSemantics);
+        expect(message).toBeUndefined();
+    });
+
     it('returns error message when seeing unexpected feature table property', function() {
         var featureTableJson = {
             INVALID : 0


### PR DESCRIPTION
Issue #117:

Updated `validateFeatureTable` and `validateFeatureTableSpec` with check for overlapping binary properties and respective test cases in spec.

It is built on the following assumptions:

- Properties have defined byteOffset where needed.
- Only properties with byteOffset are considered.