### PR TITLE
avoid calling getJsonBufferPadded twice

### DIFF
--- a/tools/bin/3d-tiles-tools.js
+++ b/tools/bin/3d-tiles-tools.js
@@ -319,10 +319,9 @@ function readGlbWriteI3dm(inputPath, outputPath, force) {
                             byteOffset : 0
                         }
                     };
-                    var featureTableJsonBuffer = getJsonBufferPadded(featureTable);
                     var featureTableBinaryBuffer = getBufferPadded(Buffer.alloc(12, 0)); // [0, 0, 0]
 
-                    return fsExtra.outputFile(outputPath, glbToI3dm(glb, featureTableJsonBuffer, featureTableBinaryBuffer));
+                    return fsExtra.outputFile(outputPath, glbToI3dm(glb, featureTable, featureTableBinaryBuffer));
                 });
         });
 }


### PR DESCRIPTION
This avoids calling getJsonBufferPadded on the featuretablejson twice. 

Once in readGlbWriteI3dm and a second time in glbToI3dm which would result in something like. 

```
{"type":"Buffer","data":[123,34,73,78,83,84,65,78,67,69,83,95,76,69,78,71,84,72,34,58,49,44,34,80,79,83,73,84,73,79,78,34,58,123,34,98,121,116,101,79,102,102,115,101,116,34,58,48,125,125,32,32,32,32,32,32]}
```
That would in turn lead to a cesium loading error ""Error: Feature table global property: INSTANCES_LENGTH must be defined""