### PR TITLE
Fix samples so they pass validation

### DIFF
--- a/samples-generator/bin/3d-tiles-samples-generator.js
+++ b/samples-generator/bin/3d-tiles-samples-generator.js
@@ -2571,7 +2571,6 @@ function createTilesetUniform() {
 
     var externalTile2 = clone(tilesetJson.root, true);
     delete externalTile2.transform;
-    delete externalTile2.refine;
     delete externalTile2.content;
 
     var tileset2Json = clone(tilesetJson, true);

--- a/samples-generator/lib/createBuildingsTile.js
+++ b/samples-generator/lib/createBuildingsTile.js
@@ -21,6 +21,7 @@ module.exports = createBuildingsTile;
 
 var sizeOfUint8 = 1;
 var sizeOfFloat = 4;
+var sizeOfDouble = 8;
 
 var scratchMatrix = new Matrix4();
 var batchTableJsonAndBinary;
@@ -201,7 +202,7 @@ function generateBatchTableExtra(buildings) {
 
 function generateBatchTableBinary(buildings) {
     var buildingsLength = buildings.length;
-    var cartographicBuffer = Buffer.alloc(buildingsLength * 3 * sizeOfFloat);
+    var cartographicBuffer = Buffer.alloc(buildingsLength * 3 * sizeOfDouble);
     var codeBuffer = Buffer.alloc(buildingsLength * sizeOfUint8);
 
     var batchTableJson = {
@@ -220,9 +221,9 @@ function generateBatchTableBinary(buildings) {
     for (var i = 0; i < buildingsLength; ++i) {
         var building = buildings[i];
         var code = Math.max(i, 255);
-        cartographicBuffer.writeFloatLE(building.longitude, (i * 3) * sizeOfFloat);
-        cartographicBuffer.writeFloatLE(building.latitude, (i * 3 + 1) * sizeOfFloat);
-        cartographicBuffer.writeFloatLE(building.height, (i * 3 + 2) * sizeOfFloat);
+        cartographicBuffer.writeDoubleLE(building.longitude, (i * 3) * sizeOfDouble);
+        cartographicBuffer.writeDoubleLE(building.latitude, (i * 3 + 1) * sizeOfDouble);
+        cartographicBuffer.writeDoubleLE(building.height, (i * 3 + 2) * sizeOfDouble);
         codeBuffer.writeUInt8(code, i);
     }
 

--- a/samples-generator/lib/createI3dm.js
+++ b/samples-generator/lib/createI3dm.js
@@ -20,7 +20,10 @@ module.exports = createI3dm;
  * @returns {Buffer} The generated i3dm tile buffer.
  */
 function createI3dm(options) {
-    var featureTableJson = getJsonBufferPadded(options.featureTableJson);
+    var version = 1;
+    var headerByteLength = 32;
+
+    var featureTableJson = getJsonBufferPadded(options.featureTableJson, headerByteLength);
     var featureTableBinary = getBufferPadded(options.featureTableBinary);
     var batchTableJson = getJsonBufferPadded(options.batchTableJson);
     var batchTableBinary = getBufferPadded(options.batchTableBinary);
@@ -28,8 +31,6 @@ function createI3dm(options) {
     var gltfFormat = defined(options.glb) ? 1 : 0;
     var gltfBuffer = defined(options.glb) ? options.glb : getGltfUriBuffer(options.uri);
 
-    var version = 1;
-    var headerByteLength = 32;
     var featureTableJsonByteLength = featureTableJson.length;
     var featureTableBinaryByteLength = featureTableBinary.length;
     var batchTableJsonByteLength = batchTableJson.length;

--- a/samples-generator/lib/createPnts.js
+++ b/samples-generator/lib/createPnts.js
@@ -15,13 +15,14 @@ module.exports = createPnts;
  * @returns {Buffer} The generated pnts tile buffer.
  */
 function createPnts(options) {
-    var featureTableJson = getJsonBufferPadded(options.featureTableJson);
+    var version = 1;
+    var headerByteLength = 28;
+
+    var featureTableJson = getJsonBufferPadded(options.featureTableJson, headerByteLength);
     var featureTableBinary = getBufferPadded(options.featureTableBinary);
     var batchTableJson = getJsonBufferPadded(options.batchTableJson);
     var batchTableBinary = getBufferPadded(options.batchTableBinary);
 
-    var version = 1;
-    var headerByteLength = 28;
     var featureTableJsonByteLength = featureTableJson.length;
     var featureTableBinaryByteLength = featureTableBinary.length;
     var batchTableJsonByteLength = batchTableJson.length;


### PR DESCRIPTION
All samples in the 1.0 path now pass validation in https://github.com/CesiumGS/3d-tiles-validator/tree/master/validator

* Fixed feature table alignment issues for pnts
* Fixed `refine` not being present in external tileset
* Fixed `cartographic` property extending beyond feature table bounds.