### PR TITLE
Add unicode property name example

### DIFF
--- a/samples-generator/bin/3d-tiles-samples-generator.ts
+++ b/samples-generator/bin/3d-tiles-samples-generator.ts
@@ -163,6 +163,7 @@ var promises = [
     createPointCloudQuantizedOctEncoded(),
     createPointCloudBatched(),
     createPointCloudWithPerPointProperties(),
+    createPointCloudWithUnicodePropertyNames(),
     createPointCloudWithTransform(),
     createPointCloudDraco(),
     createPointCloudDracoPartial(),
@@ -645,6 +646,24 @@ function createPointCloudWithPerPointProperties() {
         tileOptions,
         tilesetOptions
     );
+}
+
+function createPointCloudWithUnicodePropertyNames() {
+  var tileOptions = {
+      perPointProperties: true,
+      transform: Matrix4.IDENTITY,
+      relativeToCenter: false,
+      unicodePropertyNames: true
+  };
+  var tilesetOptions = {
+      transform: pointCloudTransform,
+      sphere: pointCloudSphereLocal
+  };
+  return savePointCloudTileset(
+      'PointCloudWithUnicodePropertyNames',
+      tileOptions,
+      tilesetOptions
+  );
 }
 
 function createPointCloudWithTransform() {

--- a/samples-generator/lib/createPointCloudTile.ts
+++ b/samples-generator/lib/createPointCloudTile.ts
@@ -48,6 +48,7 @@ var encoderModule = draco3d.createEncoderModule({});
  * @param {Boolean} [options.batched=false] Group points together with batch ids and generate per-batch metadata. Good for differentiating different sections of a point cloud. Not compatible with perPointProperties.
  * @param {Boolean} [options.perPointProperties=false] Generate per-point metadata.
  * @param {Boolean} [options.relativeToCenter=true] Define point positions relative-to-center.
+ * @param {Boolean} [options.unicodePropertyNames=false] Use unicode characters in per-point property names.
  * @param {Boolean} [options.time=0.0] Time value when generating 4D simplex noise.
  *
  * @returns {Object} An object containing the pnts buffer and batch table JSON.
@@ -74,6 +75,10 @@ export function createPointCloudTile(options) {
     var batched = defaultValue(options.batched, false);
     var perPointProperties = defaultValue(options.perPointProperties, false);
     var relativeToCenter = defaultValue(options.relativeToCenter, true);
+    var unicodePropertyNames = defaultValue(
+        options.unicodePropertyNames,
+        false
+    );
     var time = defaultValue(options.time, 0.0);
 
     if (colorMode === 'rgb565' && draco) {
@@ -147,7 +152,8 @@ export function createPointCloudTile(options) {
         batchTableProperties = getPerPointBatchTableProperties(
             pointsLength,
             noiseValues,
-            use3dTilesNext
+            use3dTilesNext,
+            unicodePropertyNames
         );
     }
 
@@ -1083,7 +1089,8 @@ function getBatchTableForBatchedPoints(batchLength, use3dTilesNext) {
 function getPerPointBatchTableProperties(
     pointsLength,
     noiseValues,
-    use3dTilesNext
+    use3dTilesNext,
+    unicodePropertyNames
 ) {
     // Create some sample per-point properties. Each point will have a temperature, secondary color, and id.
     var temperaturesBuffer = Buffer.alloc(pointsLength * sizeOfFloat32);
@@ -1144,10 +1151,14 @@ function getPerPointBatchTableProperties(
         );
     }
 
+    var temperatureName = unicodePropertyNames
+        ? 'temperature ℃'
+        : 'temperature';
+
     var result: any = [
         {
             buffer: temperaturesBuffer,
-            propertyName: 'temperature',
+            propertyName: temperatureName,
             componentType: 'FLOAT',
             type: 'SCALAR'
         },


### PR DESCRIPTION
For https://github.com/CesiumGS/cesium/pull/8785.
https://github.com/CesiumGS/3d-tiles-validator/pull/198 should be merged first.

Creates a new sample that has the property name "temperature ℃" instead of "temperature". Checked that .pnts, .gltf, and .glb code paths all produce correct results.