### PR TITLE
Validate 3DTILES_content_gltf extension

### DIFF
--- a/validator/bin/3d-tiles-validator.js
+++ b/validator/bin/3d-tiles-validator.js
@@ -49,11 +49,11 @@ const argv = yargs
     }).parse(args);
 
 async function validate(argv) {
-    let filePath = argv.input;
+    const filePath = argv.input;
     const writeReports = argv.writeReports;
     let message;
 
-    let reader = {
+    const reader = {
         readBinary: readTile,
         readJson: readTileset
     };

--- a/validator/lib/isTile.js
+++ b/validator/lib/isTile.js
@@ -5,7 +5,7 @@ const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 module.exports = isTile;
 
-var emptyArray = [];
+const EMPTY_ARRAY = [];
 
 /**
  * Checks whether the given file path is a tile file path.
@@ -15,19 +15,19 @@ var emptyArray = [];
  * @returns {Boolean} True if the file path is a tile file path, false if not.
  */
 function isTile(filePath, options) {
-    var extension = path.extname(filePath);
+    const extension = path.extname(filePath);
     if (defined(options)) {
-        var version = options.version;
-        var tileset = options.tileset;
-        var extensionsUsed = defaultValue(tileset.extensionsUsed, emptyArray);
-        var hasContentGltfExtension = extensionsUsed.indexOf('3DTILES_content_gltf') > -1;
+        const version = options.version;
+        const tileset = options.tileset;
+        const extensionsUsed = defaultValue(tileset.extensionsUsed, EMPTY_ARRAY);
+        const hasContentGltfExtension = extensionsUsed.indexOf('3DTILES_content_gltf') > -1;
 
         // Version "2.0.0-alpha.0" was used during early development of 3D Tiles Next
         // and is included here for backwards compatibility purposes
         if (version === '2.0.0-alpha.0' || hasContentGltfExtension) {
             return (
                 extension === '.gltf' ||
-                extension === '.glb' || 
+                extension === '.glb' ||
                 extension === '.b3dm' ||
                 extension === '.i3dm' ||
                 extension === '.pnts' ||
@@ -38,15 +38,14 @@ function isTile(filePath, options) {
                 extension === '.i3dm' ||
                 extension === '.pnts' ||
                 extension === '.cmpt');
-        } else {
-            return false;
         }
+        return false;
     }
 
     // if no version specified, match any
     return (
         extension === '.gltf' ||
-        extension === '.glb' || 
+        extension === '.glb' ||
         extension === '.b3dm' ||
         extension === '.i3dm' ||
         extension === '.pnts' ||

--- a/validator/lib/isTile.js
+++ b/validator/lib/isTile.js
@@ -22,6 +22,8 @@ function isTile(filePath, options) {
         var extensionsUsed = defaultValue(tileset.extensionsUsed, emptyArray);
         var hasContentGltfExtension = extensionsUsed.indexOf('3DTILES_content_gltf') > -1;
 
+        // Version "2.0.0-alpha.0" was used during early development of 3D Tiles Next
+        // and is included here for backwards compatibility purposes
         if (version === '2.0.0-alpha.0' || hasContentGltfExtension) {
             return (
                 extension === '.gltf' ||

--- a/validator/lib/isTile.js
+++ b/validator/lib/isTile.js
@@ -1,29 +1,41 @@
 'use strict';
 const path = require('path');
 const Cesium = require('cesium');
+const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 module.exports = isTile;
+
+var emptyArray = [];
 
 /**
  * Checks whether the given file path is a tile file path.
  *
  * @param {String} filePath The file path.
- * @param {String} version The tileset version
+ * @param {Object} [options] Options object
  * @returns {Boolean} True if the file path is a tile file path, false if not.
  */
-function isTile(filePath, version) {
+function isTile(filePath, options) {
     var extension = path.extname(filePath);
-    if (defined(version)) {
-        if (version === '1.0') {
+    if (defined(options)) {
+        var version = options.version;
+        var tileset = options.tileset;
+        var extensionsUsed = defaultValue(tileset.extensionsUsed, emptyArray);
+        var hasContentGltfExtension = extensionsUsed.indexOf('3DTILES_content_gltf') > -1;
+
+        if (version === '2.0.0-alpha.0' || hasContentGltfExtension) {
+            return (
+                extension === '.gltf' ||
+                extension === '.glb' || 
+                extension === '.b3dm' ||
+                extension === '.i3dm' ||
+                extension === '.pnts' ||
+                extension === '.cmpt');
+        } else if (version === '1.0') {
             return (
                 extension === '.b3dm' ||
                 extension === '.i3dm' ||
                 extension === '.pnts' ||
                 extension === '.cmpt');
-        } else if (version === '2.0.0-alpha.0') {
-            return (
-                extension === '.gltf' ||
-                extension === '.glb');
         } else {
             return false;
         }

--- a/validator/lib/utility.js
+++ b/validator/lib/utility.js
@@ -24,7 +24,7 @@ module.exports = {
 function normalizePath(path) {
     // on Windows, the paths get backslashes (due to path.join)
     // normalize that to be able to deal with internal zip paths
-    let res = path.replace(/\.\//, "");
+    const res = path.replace(/\.\//, '');
     return res.replace(/\\/g, '/');
 }
 

--- a/validator/lib/validateExtensions.js
+++ b/validator/lib/validateExtensions.js
@@ -23,6 +23,16 @@ function validateExtensions(options) {
     const extensionsUsed = defaultValue(tileset.extensionsUsed, EMPTY_ARRAY);
     const extensionsRequired = defaultValue(tileset.extensionsRequired, EMPTY_ARRAY);
 
+    let message = validateExtensionsArray(extensionsUsed, 'extensionsUsed');
+    if (defined(message)) {
+        return message;
+    }
+
+    message = validateExtensionsArray(extensionsRequired, 'extensionsRequired');
+    if (defined(message)) {
+        return message;
+    }
+
     if (defined(extensions)) {
         for (const extensionName in extensions) {
             if (extensions.hasOwnProperty(extensionName)) {
@@ -34,7 +44,6 @@ function validateExtensions(options) {
                     return `${extensionName} must be included in extensionsRequired`;
                 }
 
-                let message;
                 if (extensionName === '3DTILES_content_gltf') {
                     message = validate3DTilesContentGltf(extension);
                 }
@@ -50,23 +59,27 @@ function validate3DTilesContentGltf(extension) {
     const gltfExtensionsUsed = defaultValue(extension.extensionsUsed, EMPTY_ARRAY);
     const gltfExtensionsRequired = defaultValue(extension.extensionsRequired, EMPTY_ARRAY);
 
-    if (!Array.isArray(gltfExtensionsUsed)) {
-        return 'extensionsUsed must be an array of strings';
+    let message = validateExtensionsArray(gltfExtensionsUsed, 'extensionsUsed');
+    if (defined(message)) {
+        return message;
     }
 
-    if (!Array.isArray(gltfExtensionsRequired)) {
-        return 'extensionsRequired must be an array of strings';
+    message = validateExtensionsArray(gltfExtensionsRequired, 'extensionsRequired');
+    if (defined(message)) {
+        return message;
+    }
+}
+
+function validateExtensionsArray(array, name) {
+    const message = `${name} must be an array of strings`;
+
+    if (!Array.isArray(array)) {
+        return message;
     }
 
-    for (let i = 0; i < gltfExtensionsUsed.length; ++i) {
-        if (typeof gltfExtensionsUsed[i] !== 'string') {
-            return 'extensionsUsed must be an array of strings';
-        }
-    }
-
-    for (let i = 0; i < gltfExtensionsRequired.length; ++i) {
-        if (typeof gltfExtensionsRequired[i] !== 'string') {
-            return 'extensionsRequired must be an array of strings';
+    for (let i = 0; i < array.length; ++i) {
+        if (typeof array[i] !== 'string') {
+            return message;
         }
     }
 }

--- a/validator/lib/validateExtensions.js
+++ b/validator/lib/validateExtensions.js
@@ -1,0 +1,72 @@
+'use strict';
+const Cesium = require('cesium');
+
+const defaultValue = Cesium.defaultValue;
+const defined = Cesium.defined;
+
+module.exports = validateExtensions;
+
+const EMPTY_ARRAY = [];
+
+const requiredExtensions = ['3DTILES_content_gltf'];
+
+/**
+ * Check if a tileset's extensions are valid.
+ *
+ * @param {Object} options An object with the following properties:
+ * @param {Object} options.tileset The tileset JSON.
+ * @returns {String} An error message if validation fails, otherwise undefined.
+ */
+function validateExtensions(options) {
+    const tileset = options.tileset;
+    const extensions = tileset.extensions;
+    const extensionsUsed = defaultValue(tileset.extensionsUsed, EMPTY_ARRAY);
+    const extensionsRequired = defaultValue(tileset.extensionsRequired, EMPTY_ARRAY);
+
+    if (defined(extensions)) {
+        for (const extensionName in extensions) {
+            if (extensions.hasOwnProperty(extensionName)) {
+                const extension = extensions[extensionName];
+                if (!extensionsUsed.includes(extensionName)) {
+                    return `${extensionName} must be included in extensionsUsed`;
+                }
+                if (requiredExtensions.includes(extensionName) && !extensionsRequired.includes(extensionName)) {
+                    return `${extensionName} must be included in extensionsRequired`;
+                }
+
+                let message;
+                if (extensionName === '3DTILES_content_gltf') {
+                    message = validate3DTilesContentGltf(extension);
+                }
+                if (defined(message)) {
+                    return `Error in ${extensionName}: ${message}`;
+                }
+            }
+        }
+    }
+}
+
+function validate3DTilesContentGltf(extension) {
+    const gltfExtensionsUsed = defaultValue(extension.extensionsUsed, EMPTY_ARRAY);
+    const gltfExtensionsRequired = defaultValue(extension.extensionsRequired, EMPTY_ARRAY);
+
+    if (!Array.isArray(gltfExtensionsUsed)) {
+        return 'extensionsUsed must be an array of strings';
+    }
+
+    if (!Array.isArray(gltfExtensionsRequired)) {
+        return 'extensionsRequired must be an array of strings';
+    }
+
+    for (let i = 0; i < gltfExtensionsUsed.length; ++i) {
+        if (typeof gltfExtensionsUsed[i] !== 'string') {
+            return 'extensionsUsed must be an array of strings';
+        }
+    }
+
+    for (let i = 0; i < gltfExtensionsRequired.length; ++i) {
+        if (typeof gltfExtensionsRequired[i] !== 'string') {
+            return 'extensionsRequired must be an array of strings';
+        }
+    }
+}

--- a/validator/lib/validateGltf.js
+++ b/validator/lib/validateGltf.js
@@ -26,11 +26,11 @@ async function validateGltf(options) {
     const directory = options.directory;
     const reader = options.reader;
     const writeReports = defaultValue(options.writeReports, false);
-    
-    let gltf = bufferToJson(buffer);
-    var version = gltf.asset.version;
 
-    if (version !== "2.0") {
+    const gltf = bufferToJson(buffer);
+    const version = gltf.asset.version;
+
+    if (version !== '2.0') {
         return 'Invalid Gltf version: ' + version + '. Version must be 2.0';
     }
 

--- a/validator/lib/validateTile.js
+++ b/validator/lib/validateTile.js
@@ -16,7 +16,7 @@ module.exports = validateTile;
  * @param {Buffer} options.content A buffer containing the contents of the tile.
  * @param {String} options.filePath The tile's file path.
  * @param {String} options.directory The tile's directory.
- * @param {Object} options.reader The resource reader. 
+ * @param {Object} options.reader The resource reader.
  * @param {Boolean} [options.writeReports=false] Write glTF error report next to the glTF file in question.
  * @returns {Promise} A promise that resolves when the validation completes. If the validation fails, the promise will resolve to an error message.
  */

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -5,8 +5,6 @@ const Promise = require('bluebird');
 
 const isDataUri = require('./isDataUri');
 const isTile = require('./isTile');
-const readTile = require('./readTile');
-const readTileset = require('./readTileset');
 const utility = require('./utility');
 const validateExtensions = require('./validateExtensions');
 const validateTile = require('./validateTile');
@@ -66,7 +64,7 @@ function validateTopLevel(tileset) {
         return 'Tileset must declare a version in its asset property';
     }
 
-    if (tileset.asset.version !== "1.0" && tileset.asset.version !== "2.0.0-alpha.0") {
+    if (tileset.asset.version !== '1.0' && tileset.asset.version !== '2.0.0-alpha.0') {
         return `Tileset version must be 1.0 or 2.0.0-alpha.0. Tileset version provided: ${tileset.asset.version}`;
     }
 }
@@ -103,10 +101,8 @@ async function validateTileHierarchy(root, options) {
         if (defined(content) && defined(content.uri)) {
             if (isDataUri(content.uri)) {
                 contentPaths.push(content.uri);
-            } else {
-                if (!options.onlyValidateTilesets || content.uri.endsWith(".json")) {
-                    contentPaths.push(path.join(directory, content.uri));
-                }
+            } else if (!options.onlyValidateTilesets || content.uri.endsWith('.json')) {
+                contentPaths.push(path.join(directory, content.uri));
             }
         }
 

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -28,7 +28,7 @@ module.exports = validateTileset;
  * Check if a tileset is valid, including the tileset JSON and all tiles referenced within.
  *
  * @param {Object} options An object with the following properties:
- * @param {Buffer} options.tileset The tileset JSON.
+ * @param {Object} options.tileset The tileset JSON.
  * @param {String} options.filePath The tileset JSON file path.
  * @param {Boolean} options.onlyValidateTilesets Only check tilesets, skip any other tile type.
  * @param {String} options.directory The directory containing the tileset JSON that all paths in the tileset JSON are relative to.
@@ -173,7 +173,7 @@ async function validateContent(contentPath, directory, options) {
                 directory: directory,
                 writeReports: options.writeReports
             });
-        } else if (isTile(contentPath, options.version)) {
+        } else if (isTile(contentPath, options)) {
             if (options.onlyValidateTilesets) {
                 return;
             }

--- a/validator/lib/validateTileset.js
+++ b/validator/lib/validateTileset.js
@@ -8,6 +8,7 @@ const isTile = require('./isTile');
 const readTile = require('./readTile');
 const readTileset = require('./readTileset');
 const utility = require('./utility');
+const validateExtensions = require('./validateExtensions');
 const validateTile = require('./validateTile');
 
 const Cartesian3 = Cesium.Cartesian3;
@@ -36,7 +37,11 @@ module.exports = validateTileset;
  */
 async function validateTileset(options) {
     const tileset = options.tileset;
-    const message = validateTopLevel(tileset);
+    let message = validateTopLevel(tileset);
+    if (defined(message)) {
+        return message;
+    }
+    message = validateExtensions(options);
     if (defined(message)) {
         return message;
     }

--- a/validator/specs/lib/validateExtensionsSpec.js
+++ b/validator/specs/lib/validateExtensionsSpec.js
@@ -19,6 +19,50 @@ const sampleTileset = {
 };
 
 describe('validateExtensions', () => {
+    it('returns error message when extensionsUsed is not an array of strings (1)', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensionsUsed = {};
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = 'extensionsUsed must be an array of strings';
+        expect(message).toBe(error);
+    });
+
+    it('returns error message when extensionsUsed is not an array of strings (2)', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensionsUsed = ['3DTILES_content_gltf', 10];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = 'extensionsUsed must be an array of strings';
+        expect(message).toBe(error);
+    });
+
+    it('returns error message when extensionsRequired is not an array of strings (1)', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensionsRequired = {};
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = 'extensionsRequired must be an array of strings';
+        expect(message).toBe(error);
+    });
+
+    it('returns error message when extensionsRequired is not an array of strings (2)', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensionsRequired = ['3DTILES_content_gltf', 10];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = 'extensionsRequired must be an array of strings';
+        expect(message).toBe(error);
+    });
+
     it('returns error message when extension is not included in extensionsUsed', () => {
         const tileset = clone(sampleTileset, true);
         tileset.extensions = {

--- a/validator/specs/lib/validateExtensionsSpec.js
+++ b/validator/specs/lib/validateExtensionsSpec.js
@@ -1,0 +1,154 @@
+'use strict';
+const Cesium = require('cesium');
+const validateExtensions = require('../../lib/validateExtensions');
+
+const clone = Cesium.clone;
+
+const sampleTileset = {
+    asset: {
+        version: '1.0'
+    },
+    geometricError: 240,
+    root: {
+        boundingVolume: {
+            region: [-1.3197209591796106, 0.6988424218, -1.3196390408203893, 0.6989055782, 0, 88]
+        },
+        geometricError: 70,
+        refine: 'ADD'
+    }
+};
+
+describe('validateExtensions', () => {
+    it('returns error message when extension is not included in extensionsUsed', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensions = {
+            '3DTILES_content_gltf' : {}
+        };
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = '3DTILES_content_gltf must be included in extensionsUsed';
+        expect(message).toBe(error);
+    });
+
+    it('returns error message when extension is required and is not included in extensionsRequired', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensions = {
+            '3DTILES_content_gltf' : {}
+        };
+
+        tileset.extensionsUsed = ['3DTILES_content_gltf'];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = '3DTILES_content_gltf must be included in extensionsRequired';
+        expect(message).toBe(error);
+    });
+
+    it('validates 3DTILES_content_gltf', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensions = {
+            '3DTILES_content_gltf' : {}
+        };
+
+        tileset.extensionsUsed = ['3DTILES_content_gltf'];
+        tileset.extensionsRequired = ['3DTILES_content_gltf'];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        expect(message).toBeUndefined();
+    });
+
+    it('validates 3DTILES_content_gltf with glTF extensionsUsed and extensionsRequired', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensions = {
+            '3DTILES_content_gltf' : {
+                extensionsUsed : ['KHR_texture_transform'],
+                extensionsRequired : ['KHR_texture_transform']
+            }
+        };
+
+        tileset.extensionsUsed = ['3DTILES_content_gltf'];
+        tileset.extensionsRequired = ['3DTILES_content_gltf'];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        expect(message).toBeUndefined();
+    });
+
+    it('returns error message when 3DTILES_content_gltf extensionsUsed is not an array of strings (1)', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensions = {
+            '3DTILES_content_gltf' : {
+                extensionsUsed : 'error'
+            }
+        };
+
+        tileset.extensionsUsed = ['3DTILES_content_gltf'];
+        tileset.extensionsRequired = ['3DTILES_content_gltf'];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = 'Error in 3DTILES_content_gltf: extensionsUsed must be an array of strings';
+        expect(message).toBe(error);
+    });
+
+    it('returns error message when 3DTILES_content_gltf extensionsUsed is not an array of strings (2)', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensions = {
+            '3DTILES_content_gltf' : {
+                extensionsUsed : ['KHR_texture_transform', 10]
+            }
+        };
+
+        tileset.extensionsUsed = ['3DTILES_content_gltf'];
+        tileset.extensionsRequired = ['3DTILES_content_gltf'];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = 'Error in 3DTILES_content_gltf: extensionsUsed must be an array of strings';
+        expect(message).toBe(error);
+    });
+
+    it('returns error message when 3DTILES_content_gltf extensionsRequired is not an array of strings (1)', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensions = {
+            '3DTILES_content_gltf' : {
+                extensionsRequired : 'error'
+            }
+        };
+
+        tileset.extensionsUsed = ['3DTILES_content_gltf'];
+        tileset.extensionsRequired = ['3DTILES_content_gltf'];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = 'Error in 3DTILES_content_gltf: extensionsRequired must be an array of strings';
+        expect(message).toBe(error);
+    });
+
+    it('returns error message when 3DTILES_content_gltf extensionsRequired is not an array of strings (2)', () => {
+        const tileset = clone(sampleTileset, true);
+        tileset.extensions = {
+            '3DTILES_content_gltf' : {
+                extensionsRequired : ['KHR_texture_transform', 10]
+            }
+        };
+
+        tileset.extensionsUsed = ['3DTILES_content_gltf'];
+        tileset.extensionsRequired = ['3DTILES_content_gltf'];
+
+        const message = validateExtensions({
+            tileset: tileset
+        });
+        const error = 'Error in 3DTILES_content_gltf: extensionsRequired must be an array of strings';
+        expect(message).toBe(error);
+    });
+});

--- a/validator/specs/lib/validateGlbSpec.js
+++ b/validator/specs/lib/validateGlbSpec.js
@@ -7,7 +7,7 @@ describe('validate Glb', () => {
         const glb = specUtility.createGlb();
         glb.writeUInt32LE(1, 4);  // version
         const message = await validateGlb({
-            glb: glb,
+            content: glb,
             filePath: 'filepath'
         });
         expect(message).toBe('Invalid Glb version: 1. Version must be 2.');

--- a/validator/specs/lib/validateTilesetSpec.js
+++ b/validator/specs/lib/validateTilesetSpec.js
@@ -142,7 +142,7 @@ describe('validateTileset', () => {
             filePath: 'filepath',
             directory: '.'
         });
-        expect(message).toBe(`Tileset version must be 1.0. Tileset version provided: ${tileset.asset.version}`);
+        expect(message).toBe(`Tileset version must be 1.0 or 2.0.0-alpha.0. Tileset version provided: ${tileset.asset.version}`);
     });
 
     it('returns error message when a content\'s box type boundingVolume is not within it\'s tile\'s box type boundingVolume [invalid aligned bounding boxes]', async () => {


### PR DESCRIPTION
This PR adds support for the `3DTILES_content_gltf` extension which allows a tileset to refer to glTF and glb content directly.
There's still backwards compatible support for tilesets with version `'2.0.0-alpha.0'`

See https://github.com/CesiumGS/3d-tiles/pull/427 for the in-progress spec.