### PR TITLE
Update gltf-pipeline to 3.0.1

### DIFF
--- a/samples-generator/package.json
+++ b/samples-generator/package.json
@@ -30,7 +30,7 @@
     "cesium": "^1.71.0",
     "draco3d": "1.3.6",
     "fs-extra": "^9.0.1",
-    "gltf-pipeline": "^2.1.10",
+    "gltf-pipeline": "^3.0.1",
     "mime": "^2.4.6",
     "simplex-noise": "^2.4.0"
   },


### PR DESCRIPTION
Projects using gltf-pipeline, including 3d-tiles-samples-generator, need to upgrade to gltf-pipeline 3.0.1 or above to avoid Draco module initialization issues once Draco 1.4.0 is released. See https://github.com/CesiumGS/gltf-pipeline/pull/563.

This doesn't affect 3d-tiles-tools because that is still using the 1.x.x series of gltf-pipeline which predates Draco in gltf-pipeline.