### PR TITLE
b3dm file sizes should be a multiple of 8 bytes.

### DIFF
--- a/samples-generator/lib/createB3dm.js
+++ b/samples-generator/lib/createB3dm.js
@@ -21,9 +21,9 @@ module.exports = createB3dm;
  * @returns {Buffer} The generated b3dm tile buffer.
  */
 function createB3dm(options) {
-    var glb = options.glb;
+    var glb = getBufferPadded(options.glb);
     var defaultFeatureTable = {
-        BATCH_LENGTH : 0
+        BATCH_LENGTH: 0
     };
     var featureTableJson = defaultValue(options.featureTableJson, defaultFeatureTable);
     var batchLength = featureTableJson.BATCH_LENGTH;

--- a/validator/lib/validateB3dm.js
+++ b/validator/lib/validateB3dm.js
@@ -63,6 +63,10 @@ async function validateB3dm(options) {
         return `byteLength of ${byteLength} does not equal the tile\'s actual byte length of ${content.length}.`;
     }
 
+    if (byteLength % 8 > 0) {
+        return `byteLength of ${byteLength} must be aligned to an 8-byte boundary.`;
+    }
+
     // Legacy header #1: [batchLength] [batchTableByteLength]
     // Legacy header #2: [batchTableJsonByteLength] [batchTableBinaryByteLength] [batchLength]
     // Current header: [featureTableJsonByteLength] [featureTableBinaryByteLength] [batchTableJsonByteLength] [batchTableBinaryByteLength]
@@ -83,15 +87,19 @@ async function validateB3dm(options) {
     let glbByteLength = Math.max(byteLength - glbByteOffset, 0);
 
     if (featureTableBinaryByteOffset % 8 > 0) {
-        return 'Feature table binary must be aligned to an 8-byte boundary.';
+        return 'Feature table Json must end on an 8-byte boundary.';
+    }
+
+    if (batchTableJsonByteOffset % 8 > 0) {
+        return 'Feature table binary must end on an 8-byte boundary.';
     }
 
     if (batchTableBinaryByteOffset % 8 > 0) {
-        return 'Batch table binary must be aligned to an 8-byte boundary.';
+        return 'Batch table Json must end on an 8-byte boundary.';
     }
 
     if (glbByteOffset % 8 > 0) {
-        return 'Glb must be aligned to an 8-byte boundary.';
+        return 'Batch table binary must end on an 8-byte boundary.';
     }
 
     if (headerByteLength + featureTableJsonByteLength + featureTableBinaryByteLength + batchTableJsonByteLength + batchTableBinaryByteLength + glbByteLength > byteLength) {


### PR DESCRIPTION
Fixes CesiumGS/3d-tiles-samples-generator#1
modify the samples-generator and validator to let b3dm file sizes(`byteLength`)  aligned to an 8-byte boundary.