### PR TITLE
Fixed param problem with `combine` script

### DIFF
--- a/tools/bin/3d-tiles-tools.js
+++ b/tools/bin/3d-tiles-tools.js
@@ -109,12 +109,12 @@ var argv = yargs
     })
     .command('ungzip', 'Ungzips the input tileset directory.')
     .command('combine', 'Combines all external tilesets into a single tileset.json file.', {
-        'r': {
-            alias: 'rootJson',
-            default: 'tileset.json',
+        'i': {
+            alias: 'input',
             description: 'Relative path to the root tileset.json file.',
             normalize: true,
-            type: 'string'
+            type: 'string',
+            demandOption: true
         }
     })
     .command('merge', 'Merge any number of tilesets together into a single tileset.', {


### PR DESCRIPTION
Fixes #214 

Fixes problem with `combine` script: https://github.com/CesiumGS/3d-tiles-validator/issues/214

The problem is that the script requires `-r` but then tries to use `-i` to find the root JSON tile.

A user requested this fix: https://community.cesium.com/t/3d-tiles-specifying-tileset-json-pointing-to-external-tilesets/15225/5