### PR TITLE
Derive S2 bounding volumes

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -51,8 +51,5 @@ The `ValidationIssue` class and its types:
 
 ### General functionality
 
-- Check that geometry is within tile.boundingVolume, content.boundingVolume, and parent.boundingVolume
 - Check that metadata statistics are correct. Or at the very least, check that metadata values fall within min/max
 - Check that metadata values fall within the class's min/max
-- Declarative styling validation
-- Should absolute URIs be resolved?

--- a/src/traversal/cesium/HilbertOrder.ts
+++ b/src/traversal/cesium/HilbertOrder.ts
@@ -1,0 +1,109 @@
+// Ported from https://github.com/CesiumGS/cesium/blob/4b333bc145fa9f7aed0c7ad7e0f46cb001a94ddd/Source/Core/HilbertOrder.js
+
+import { DeveloperError } from "../../base/DeveloperError";
+
+/**
+ * Hilbert Order helper functions.
+ */
+export class HilbertOrder {
+  /**
+   * Computes the Hilbert index at the given level from 2D coordinates.
+   *
+   * @param level The level of the curve
+   * @param x The X coordinate
+   * @param y The Y coordinate
+   * @returns  The Hilbert index.
+   */
+  static encode2D(level: number, x: number, y: number): bigint {
+    const n = Math.pow(2, level);
+    if (level < 1) {
+      throw new DeveloperError("Hilbert level cannot be less than 1.");
+    }
+    if (x < 0 || x >= n || y < 0 || y >= n) {
+      throw new DeveloperError("Invalid coordinates for given level.");
+    }
+
+    const p = {
+      x: x,
+      y: y,
+    };
+    let rx,
+      ry,
+      s,
+      // eslint-disable-next-line no-undef
+      index = BigInt(0);
+
+    for (s = n / 2; s > 0; s /= 2) {
+      rx = (p.x & s) > 0 ? 1 : 0;
+      ry = (p.y & s) > 0 ? 1 : 0;
+      // eslint-disable-next-line no-undef
+      index += BigInt(((3 * rx) ^ ry) * s * s);
+      HilbertOrder.rotate(n, p, rx, ry);
+    }
+
+    return index;
+  }
+
+  /**
+   * Computes the 2D coordinates from the Hilbert index at the given level.
+   *
+   * @param {Number} level The level of the curve
+   * @param {BigInt} index The Hilbert index
+   * @returns {Number[]} An array containing the 2D coordinates ([x, y]) corresponding to the Morton index.
+   * @private
+   */
+  static decode2D(level: number, index: bigint): number[] {
+    if (level < 1) {
+      throw new DeveloperError("Hilbert level cannot be less than 1.");
+    }
+    if (index < BigInt(0) || index >= BigInt(Math.pow(4, level))) {
+      throw new DeveloperError(
+        "Hilbert index exceeds valid maximum for given level."
+      );
+    }
+
+    const n = Math.pow(2, level);
+    const p = {
+      x: 0,
+      y: 0,
+    };
+    let rx, ry, s, t;
+
+    for (s = 1, t = index; s < n; s *= 2) {
+      // eslint-disable-next-line no-undef
+      rx = 1 & Number(t / BigInt(2));
+      // eslint-disable-next-line no-undef
+      ry = 1 & Number(t ^ BigInt(rx));
+      HilbertOrder.rotate(s, p, rx, ry);
+      p.x += s * rx;
+      p.y += s * ry;
+      // eslint-disable-next-line no-undef
+      t /= BigInt(4);
+    }
+
+    return [p.x, p.y];
+  }
+
+  /**
+   * @private
+   */
+  private static rotate(
+    n: number,
+    p: { x: number; y: number },
+    rx: number,
+    ry: number
+  ) {
+    if (ry !== 0) {
+      return;
+    }
+
+    if (rx === 1) {
+      p.x = n - 1 - p.x;
+      p.y = n - 1 - p.y;
+    }
+
+    const t = p.x;
+    p.x = p.y;
+    p.y = t;
+  }
+}

--- a/src/traversal/cesium/S2Cell.ts
+++ b/src/traversal/cesium/S2Cell.ts
@@ -1,0 +1,106 @@
+// Relevant functions ported from https://github.com/CesiumGS/cesium/blob/4b333bc145fa9f7aed0c7ad7e0f46cb001a94ddd/Source/Core/S2Cell.js
+
+import { DeveloperError } from "../../base/DeveloperError";
+
+/**
+ * Functions related to S2 cells
+ */
+export class S2Cell {
+  // The maximum level supported within an S2 cell ID. Each level is represented by two bits in the final cell ID
+  private static readonly S2_MAX_LEVEL = 30;
+
+  // The number of bits in a S2 cell ID used for specifying the position along the Hilbert curve
+  private static readonly S2_POSITION_BITS = 2 * S2Cell.S2_MAX_LEVEL + 1;
+
+  // Lookup table for getting trailing zero bits.
+  // https://graphics.stanford.edu/~seander/bithacks.html
+  private static readonly Mod67BitPosition = [
+    64, 0, 1, 39, 2, 15, 40, 23, 3, 12, 16, 59, 41, 19, 24, 54, 4, 64, 13, 10,
+    17, 62, 60, 28, 42, 30, 20, 51, 25, 44, 55, 47, 5, 32, 65, 38, 14, 22, 11,
+    58, 18, 53, 63, 9, 61, 27, 29, 50, 43, 46, 31, 37, 21, 57, 52, 8, 26, 49,
+    45, 36, 56, 7, 48, 35, 6, 34, 33, 0,
+  ];
+
+  /**
+   * Converts a 64-bit S2 cell ID to an S2 cell token.
+   *
+   * @param cellId The S2 cell ID.
+   * @returns Returns hexadecimal representation of an S2CellId.
+   * @private
+   */
+  static getTokenFromId = function (cellId: bigint): string {
+    const trailingZeroHexChars = Math.floor(
+      S2Cell.countTrailingZeroBits(cellId) / 4
+    );
+    const hexString = cellId.toString(16).replace(/0*$/, "");
+
+    const zeroString = Array(17 - trailingZeroHexChars - hexString.length).join(
+      "0"
+    );
+    return zeroString + hexString;
+  };
+
+  /**
+   * Return the number of trailing zeros in number.
+   * @private
+   */
+  private static countTrailingZeroBits(x: bigint) {
+    const index = (-x & x) % BigInt(67);
+    return S2Cell.Mod67BitPosition[Number(index)];
+  }
+
+  /**
+   * Converts an S2 cell token to a 64-bit S2 cell ID.
+   *
+   * @param token The hexadecimal representation of an S2CellId. Expected to be a valid S2 token.
+   * @returns Returns the S2 cell ID.
+   * @private
+   */
+  static getIdFromToken = function (token: string): bigint {
+    return BigInt("0x" + token + "0".repeat(16 - token.length));
+  };
+
+  /**
+   * Creates an S2Cell from its face, position along the Hilbert curve for a given level.
+   *
+   * @param face The root face of S2 this cell is on. Must be in the range [0-5].
+   * @param position The position along the Hilbert curve. Must be in the range [0-4**level).
+   * @param level The level of the S2 curve. Must be in the range [0-30].
+   * @returns A new S2Cell ID from the given parameters.
+   * @private
+   */
+  static fromFacePositionLevel(
+    face: number,
+    position: bigint,
+    level: number
+  ): bigint {
+    if (face < 0 || face > 5) {
+      throw new DeveloperError("Invalid S2 Face (must be within 0-5)");
+    }
+
+    if (level < 0 || level > S2Cell.S2_MAX_LEVEL) {
+      throw new DeveloperError("Invalid level (must be within 0-30)");
+    }
+    if (position < 0 || position >= Math.pow(4, level)) {
+      throw new DeveloperError("Invalid Hilbert position for level");
+    }
+
+    const faceBitString =
+      (face < 4 ? "0" : "") + (face < 2 ? "0" : "") + face.toString(2);
+    const positionBitString = position.toString(2);
+    const positionPrefixPadding = Array(
+      2 * level - positionBitString.length + 1
+    ).join("0");
+    const positionSuffixPadding = Array(
+      S2Cell.S2_POSITION_BITS - 2 * level
+    ).join("0");
+
+    const cellId = BigInt(
+      `0b${faceBitString}${positionPrefixPadding}${positionBitString}1${
+        // Adding the sentinel bit that always follows the position bits.
+        positionSuffixPadding
+      }`
+    );
+    return cellId;
+  }
+}

--- a/src/validation/PropertyTableValidator.ts
+++ b/src/validation/PropertyTableValidator.ts
@@ -198,7 +198,7 @@ export class PropertyTableValidator {
       return false;
     }
     // TODO Validate property table properties
-    console.log("Property table properties are not validated yet.");
+    //console.log("Property table properties are not validated yet.");
     return true;
   }
 }

--- a/src/validation/extensions/BoundingVolumeS2.ts
+++ b/src/validation/extensions/BoundingVolumeS2.ts
@@ -1,0 +1,7 @@
+import { RootProperty } from "../../structure/RootProperty";
+
+export interface BoundingVolumeS2 extends RootProperty {
+  token: string;
+  minimumHeight: number;
+  maximumHeight: number;
+}


### PR DESCRIPTION
The functions that are used for computing the "derived" bounding volumes in implicit tiles had been ported from CesiumJS, and put into the [`BoundingVolumeDerivation`](https://github.com/javagl/3d-tiles-validator/blob/e75dd490fa7e2a2f5e87a23e6d564440a27ab85f/src/traversal/cesium/BoundingVolumeDerivation.ts#L8) class. This class had been missing support for _S2_ bounding volumes in implicit tilesets. 

This PR adds the required function, namely the `deriveBoundingVolumeS2` function, in this class. 

(This required porting _parts_ of `HilbertCurve` and `S2Cell` as well, but these parts are tiny and _only_ used for the bounding volume derivation)

This has been tested with _one_ example data set, but there is not yet any coverage on the unit test level. There should probably be a small example (like the `SparseImplicitQuadtree` sample) that uses implicit tiling and S2 bounding volumes. Additionally, there has to be test data in the `specs/data/subtrees` directory for the anticipated _failures_ for this case. But this part of the spec data is likely to be refactored soon (for binary metadata validation), so this is not yet part of this PR.


