### PR TITLE
Metadata validaton - part 2

### DIFF
--- a/specs/jasmine.json
+++ b/specs/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "specs",
-  "spec_files": ["**/metadata/PropertyTablesSpec.ts"],
+  "spec_files": ["**/*Spec.*s"],
   "helpers": [],
   "random": false
 }

--- a/specs/metadata/BinaryPropertyTableValidationSpec.ts
+++ b/specs/metadata/BinaryPropertyTableValidationSpec.ts
@@ -3,138 +3,12 @@ import { ResourceResolvers } from "../../src/io/ResourceResolvers";
 import { ValidationContext } from "../../src/validation/ValidationContext";
 import { BinaryPropertyTableValidator } from "../../src/validation/metadata/BinaryPropertyTableValidator";
 
-import { BinaryPropertyTable } from "../../src/binary/BinaryPropertyTable";
-import { PropertyTableModels } from "../../src/binary/PropertyTableModels";
+import { PropertyTableTestUtilities } from "./PropertyTableTestUtilities";
 
-import { Schema } from "../../src/structure/Metadata/Schema";
-import { ClassProperty } from "../../src/structure/Metadata/ClassProperty";
+// A flag to enable printing all `ValidationResult`
+// instances to the console during the tests.
+const debugLogResults = false;
 
-/**
- * Creates an unspecified valid default `BinaryPropertyTable`, containing
- * a single example_INT16_SCALAR property
- *
- * @returns The `BinaryPropertyTable`
- */
-function createDefaultBinaryPropertyTable_example_INT16_SCALAR(): BinaryPropertyTable {
-  const example_INT16_SCALAR: ClassProperty = {
-    type: "SCALAR",
-    componentType: "INT16",
-  };
-  const example_INT16_SCALAR_values = [-32768, 32767];
-
-  const classProperty = example_INT16_SCALAR;
-  const values = example_INT16_SCALAR_values;
-
-  const testSchema: Schema = {
-    id: "testSchemaId",
-    classes: {
-      testClass: {
-        properties: {
-          testProperty: classProperty,
-        },
-      },
-    },
-  };
-
-  const arrayOffsetType = "UINT32";
-  const stringOffsetType = "UINT32";
-  const binaryPropertyTable = PropertyTableModels.createBinaryPropertyTable(
-    testSchema,
-    "testClass",
-    "testProperty",
-    values,
-    arrayOffsetType,
-    stringOffsetType
-  );
-  return binaryPropertyTable;
-}
-
-/**
- * Creates an unspecified valid default `BinaryPropertyTable`, containing
- * a single example_variable_length_INT16_SCALAR_array property
- *
- * @returns The `BinaryPropertyTable`
- */
-function createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array(): BinaryPropertyTable {
-  const example_variable_length_INT16_SCALAR_array: ClassProperty = {
-    type: "SCALAR",
-    componentType: "INT16",
-    array: true,
-  };
-  const example_variable_length_INT16_SCALAR_array_values = [
-    [-32768, 32767],
-    [-1, 0, 1],
-  ];
-
-  const classProperty = example_variable_length_INT16_SCALAR_array;
-  const values = example_variable_length_INT16_SCALAR_array_values;
-
-  const testSchema: Schema = {
-    id: "testSchemaId",
-    classes: {
-      testClass: {
-        properties: {
-          testProperty: classProperty,
-        },
-      },
-    },
-  };
-
-  const arrayOffsetType = "UINT32";
-  const stringOffsetType = "UINT32";
-  const binaryPropertyTable = PropertyTableModels.createBinaryPropertyTable(
-    testSchema,
-    "testClass",
-    "testProperty",
-    values,
-    arrayOffsetType,
-    stringOffsetType
-  );
-  return binaryPropertyTable;
-}
-
-/**
- * Creates an unspecified valid default `BinaryPropertyTable`, containing
- * a single example_STRING property
- *
- * @returns The `BinaryPropertyTable`
- */
-function createDefaultBinaryPropertyTable_example_STRING(): BinaryPropertyTable {
-  const example_STRING: ClassProperty = {
-    type: "STRING",
-  };
-  const example_STRING_values = ["FirstString", "SecondString"];
-
-  const classProperty = example_STRING;
-  const values = example_STRING_values;
-
-  const testSchema: Schema = {
-    id: "testSchemaId",
-    classes: {
-      testClass: {
-        properties: {
-          testProperty: classProperty,
-        },
-      },
-    },
-  };
-
-  const arrayOffsetType = "UINT32";
-  const stringOffsetType = "UINT32";
-  const binaryPropertyTable = PropertyTableModels.createBinaryPropertyTable(
-    testSchema,
-    "testClass",
-    "testProperty",
-    values,
-    arrayOffsetType,
-    stringOffsetType
-  );
-  return binaryPropertyTable;
-}
-
-// TODO Add the cases that should NOT report issues from the
-// PropertyTableModelsSpec file (and think about how the
-// redundancy could be reduced here...)
 describe("metadata/BinaryPropertyTableValidationSpec", function () {
   //==========================================================================
   //=== example_INT16_SCALAR test cases:
@@ -154,19 +28,22 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
 
     it("should not report issues for a valid example_INT16_SCALAR", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
         "test",
         binaryPropertyTable,
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(0);
     });
 
     it("detects unaligned values byteOffset for example_INT16_SCALAR", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
 
       // For the test: Assign a value to values
       // byteOffset to cause an invalid alignment
@@ -182,13 +59,16 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_ALIGNMENT");
     });
 
     it("detects invalid values byteLength for example_INT16_SCALAR", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
 
       // For the test: Assign a value to values
       // byteLength to cause an invalid size
@@ -204,6 +84,9 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
     });
@@ -229,19 +112,22 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
 
     it("should not report issues for a valid example_variable_length_INT16_SCALAR_array", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
         "test",
         binaryPropertyTable,
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(0);
     });
 
     it("detects unaligned arrayOffsets byteOffset for example_variable_length_INT16_SCALAR_array", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
 
       // For the test: Assign a value to arrayOffsets
       // byteOffset to cause an invalid alignment
@@ -258,13 +144,16 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_ALIGNMENT");
     });
 
     it("detects wrong arrayOffsets byteLength for example_variable_length_INT16_SCALAR_array", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
 
       // For the test: Assign a value to arrayOffsets
       // byteLength to cause an invalid length
@@ -281,13 +170,16 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
     });
 
     it("detects descending arrayOffsets for example_variable_length_INT16_SCALAR_array", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
 
       // For the test: Write a value into the arrayOffsets
       // buffer, to make it descending
@@ -306,13 +198,16 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_OFFSETS");
     });
 
     it("detects arrayOffsets that are out of range for example_variable_length_INT16_SCALAR_array", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
 
       // For the test: Write values into the arrayOffsets
       // buffer so that the 'values' buffer is not long
@@ -334,6 +229,255 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(1);
+      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+    });
+  });
+
+  //==========================================================================
+  //=== example_fixed_length_INT16_SCALAR_array test cases:
+  // - no issues for valid input
+  // - `values` length does not match in view of the `classProperty.count`
+
+  describe("issues for example_fixed_length_INT16_SCALAR_array", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_fixed_length_INT16_SCALAR_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_INT16_SCALAR_array();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+
+    it("detects invalid values byteLength for example_fixed_length_INT16_SCALAR_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_INT16_SCALAR_array();
+
+      // For the test: Assign a value to the 'count' of
+      // the property, so that the length of the 'values'
+      // buffer view does no longer match
+      binaryPropertyTable.metadataClass.properties![
+        "testProperty"
+      ].count = 12345;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(1);
+      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+    });
+  });
+
+  //==========================================================================
+  //=== example_BOOLEAN test cases:
+  // - no issues for valid input
+  // - `values` length does not match for `propertyTable.count`
+
+  describe("issues for example_BOOLEAN", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_BOOLEAN", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_BOOLEAN();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+
+    it("should not report issues for valid values byteLength for example_BOOLEAN", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_BOOLEAN();
+
+      // For the test: Assign a value to the 'count' of
+      // the property table that JUST SO fits into one
+      // byte (this should NOT cause an issue!)
+      binaryPropertyTable.propertyTable.count = 8;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+
+    it("detects invalid values byteLength for example_BOOLEAN", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_BOOLEAN();
+
+      // For the test: Assign a value to the 'count' of
+      // the property table, so that the length of the 'values'
+      // buffer view does no longer match
+      binaryPropertyTable.propertyTable.count = 9;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(1);
+      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+    });
+  });
+
+  //==========================================================================
+  //=== example_variable_length_BOOLEAN_array test cases:
+  // - no issues for valid input
+  // - `values` length does not match for given `arrayOffsets`
+
+  describe("issues for example_variable_length_BOOLEAN_array", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_variable_length_BOOLEAN_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_BOOLEAN_array();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+
+    it("detects invalid values byteLength for example_variable_length_BOOLEAN_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_BOOLEAN_array();
+
+      // For the test: Write values into the arrayOffsets
+      // buffer so that the 'values' buffer is not long
+      // enough to match the last array offsets entry
+      const arrayOffsetsBufferViewIndex =
+        binaryPropertyTable.propertyTable.properties!["testProperty"]
+          .arrayOffsets!;
+      const arrayOffsetsBufferViewData =
+        binaryPropertyTable.binaryBufferData!.bufferViewsData![
+          arrayOffsetsBufferViewIndex
+        ];
+      arrayOffsetsBufferViewData.writeInt32LE(0, 0);
+      arrayOffsetsBufferViewData.writeInt32LE(123, 4);
+      arrayOffsetsBufferViewData.writeInt32LE(12345, 8);
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(1);
+      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+    });
+  });
+
+  //==========================================================================
+  //=== example_fixed_length_BOOLEAN_array test cases:
+  // - no issues for valid input
+  // - `values` length does not match for given `arrayOffsets`
+
+  describe("issues for example_fixed_length_BOOLEAN_array", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_fixed_length_BOOLEAN_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_BOOLEAN_array();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+
+    it("detects invalid values byteLength for example_fixed_length_BOOLEAN_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_BOOLEAN_array();
+
+      // For the test: Assign a value to the 'count' of
+      // the property, so that the length of the 'values'
+      // buffer view does no longer match
+      binaryPropertyTable.metadataClass.properties![
+        "testProperty"
+      ].count = 12345;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
     });
@@ -359,19 +503,22 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
 
     it("should not report issues for a valid example_STRING", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_STRING();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
         "test",
         binaryPropertyTable,
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(0);
     });
 
     it("detects unaligned stringOffsets byteOffset for example_STRING", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_STRING();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
 
       // For the test: Assign a value to stringOffsets
       // byteOffset to cause an invalid alignment
@@ -388,13 +535,16 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_ALIGNMENT");
     });
 
     it("detects wrong stringOffsets byteLength for example_STRING", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_STRING();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
 
       // For the test: Assign a value to stringOffsets
       // byteLength to cause an invalid length
@@ -411,13 +561,16 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
     });
 
     it("detects descending stringOffsets for example_STRING", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_STRING();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
 
       // For the test: Write a value into the stringOffsets
       // buffer, to make it descending
@@ -436,13 +589,16 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_OFFSETS");
     });
 
     it("detects stringOffsets that are out of range for example_STRING", async function () {
       const binaryPropertyTable =
-        createDefaultBinaryPropertyTable_example_STRING();
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
 
       // For the test: Write values into the stringOffsets
       // buffer so that the 'values' buffer is not long
@@ -464,8 +620,166 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         context
       );
       const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
       expect(result.length).toEqual(1);
       expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+    });
+  });
+
+  //==========================================================================
+  //=== example_variable_length_STRING_array test cases
+  // - no issues for valid input
+  // (arrayOffsets issues are already covered with example_variable_length_INT16_SCALAR_array)
+  // (stringOffsets issues are already covered with example_STRING)
+
+  describe("issues for example_variable_length_STRING_array", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_variable_length_STRING_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_STRING_array();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+  });
+
+  //==========================================================================
+  //=== example_fixed_length_STRING_array test cases
+  // - no issues for valid input
+  // (stringOffsets issues are already covered with example_STRING)
+
+  describe("issues for example_fixed_length_STRING_array", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_fixed_length_STRING_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_STRING_array();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+  });
+
+  //==========================================================================
+  //=== example_FLOAT32_VEC2 test cases
+  // - no issues for valid input
+
+  describe("issues for example_FLOAT32_VEC2", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_FLOAT32_VEC2", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_FLOAT32_VEC2();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+  });
+
+  //==========================================================================
+  //=== example_variable_length_UINT32_VEC2_array test cases
+  // - no issues for valid input
+  // (arrayOffsets issues are already covered with example_variable_length_INT16_SCALAR_array)
+
+  describe("issues for example_variable_length_UINT32_VEC2_array", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_variable_length_UINT32_VEC2_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_UINT32_VEC2_array();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+  });
+
+  //==========================================================================
+  //=== example_fixed_length_UINT32_VEC2_array test cases
+  // - no issues for valid input
+  // (arrayOffsets issues are already covered with example_fixed_length_INT16_SCALAR_array)
+
+  describe("issues for example_fixed_length_UINT32_VEC2_array", function () {
+    let context: ValidationContext;
+
+    beforeEach(async function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_fixed_length_UINT32_VEC2_array", async function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_UINT32_VEC2_array();
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
     });
   });
 });

--- a/specs/metadata/BinaryPropertyTableValidationSpec.ts
+++ b/specs/metadata/BinaryPropertyTableValidationSpec.ts
@@ -19,14 +19,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_INT16_SCALAR", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_INT16_SCALAR", async function () {
+    it("should not report issues for a valid example_INT16_SCALAR", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -41,7 +41,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.length).toEqual(0);
     });
 
-    it("detects unaligned values byteOffset for example_INT16_SCALAR", async function () {
+    it("detects unaligned values byteOffset for example_INT16_SCALAR", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
 
@@ -66,7 +66,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.get(0).type).toEqual("METADATA_INVALID_ALIGNMENT");
     });
 
-    it("detects invalid values byteLength for example_INT16_SCALAR", async function () {
+    it("detects invalid values byteLength for example_INT16_SCALAR", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
 
@@ -103,14 +103,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_variable_length_INT16_SCALAR_array", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_variable_length_INT16_SCALAR_array", async function () {
+    it("should not report issues for a valid example_variable_length_INT16_SCALAR_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -125,7 +125,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.length).toEqual(0);
     });
 
-    it("detects unaligned arrayOffsets byteOffset for example_variable_length_INT16_SCALAR_array", async function () {
+    it("detects unaligned arrayOffsets byteOffset for example_variable_length_INT16_SCALAR_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
 
@@ -151,7 +151,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.get(0).type).toEqual("METADATA_INVALID_ALIGNMENT");
     });
 
-    it("detects wrong arrayOffsets byteLength for example_variable_length_INT16_SCALAR_array", async function () {
+    it("detects wrong arrayOffsets byteLength for example_variable_length_INT16_SCALAR_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
 
@@ -177,7 +177,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
     });
 
-    it("detects descending arrayOffsets for example_variable_length_INT16_SCALAR_array", async function () {
+    it("detects descending arrayOffsets for example_variable_length_INT16_SCALAR_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
 
@@ -205,7 +205,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.get(0).type).toEqual("METADATA_INVALID_OFFSETS");
     });
 
-    it("detects arrayOffsets that are out of range for example_variable_length_INT16_SCALAR_array", async function () {
+    it("detects arrayOffsets that are out of range for example_variable_length_INT16_SCALAR_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array();
 
@@ -245,14 +245,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_fixed_length_INT16_SCALAR_array", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_fixed_length_INT16_SCALAR_array", async function () {
+    it("should not report issues for a valid example_fixed_length_INT16_SCALAR_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_INT16_SCALAR_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -267,7 +267,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.length).toEqual(0);
     });
 
-    it("detects invalid values byteLength for example_fixed_length_INT16_SCALAR_array", async function () {
+    it("detects invalid values byteLength for example_fixed_length_INT16_SCALAR_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_INT16_SCALAR_array();
 
@@ -300,14 +300,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_BOOLEAN", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_BOOLEAN", async function () {
+    it("should not report issues for a valid example_BOOLEAN", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_BOOLEAN();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -322,7 +322,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.length).toEqual(0);
     });
 
-    it("should not report issues for valid values byteLength for example_BOOLEAN", async function () {
+    it("should not report issues for valid values byteLength for example_BOOLEAN", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_BOOLEAN();
 
@@ -343,7 +343,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.length).toEqual(0);
     });
 
-    it("detects invalid values byteLength for example_BOOLEAN", async function () {
+    it("detects invalid values byteLength for example_BOOLEAN", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_BOOLEAN();
 
@@ -374,14 +374,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_variable_length_BOOLEAN_array", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_variable_length_BOOLEAN_array", async function () {
+    it("should not report issues for a valid example_variable_length_BOOLEAN_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_BOOLEAN_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -396,7 +396,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.length).toEqual(0);
     });
 
-    it("detects invalid values byteLength for example_variable_length_BOOLEAN_array", async function () {
+    it("detects invalid values byteLength for example_variable_length_BOOLEAN_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_BOOLEAN_array();
 
@@ -436,14 +436,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_fixed_length_BOOLEAN_array", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_fixed_length_BOOLEAN_array", async function () {
+    it("should not report issues for a valid example_fixed_length_BOOLEAN_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_BOOLEAN_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -458,7 +458,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.length).toEqual(0);
     });
 
-    it("detects invalid values byteLength for example_fixed_length_BOOLEAN_array", async function () {
+    it("detects invalid values byteLength for example_fixed_length_BOOLEAN_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_BOOLEAN_array();
 
@@ -494,14 +494,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_STRING", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_STRING", async function () {
+    it("should not report issues for a valid example_STRING", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -516,7 +516,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.length).toEqual(0);
     });
 
-    it("detects unaligned stringOffsets byteOffset for example_STRING", async function () {
+    it("detects unaligned stringOffsets byteOffset for example_STRING", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
 
@@ -542,7 +542,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.get(0).type).toEqual("METADATA_INVALID_ALIGNMENT");
     });
 
-    it("detects wrong stringOffsets byteLength for example_STRING", async function () {
+    it("detects wrong stringOffsets byteLength for example_STRING", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
 
@@ -568,7 +568,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
     });
 
-    it("detects descending stringOffsets for example_STRING", async function () {
+    it("detects descending stringOffsets for example_STRING", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
 
@@ -596,7 +596,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
       expect(result.get(0).type).toEqual("METADATA_INVALID_OFFSETS");
     });
 
-    it("detects stringOffsets that are out of range for example_STRING", async function () {
+    it("detects stringOffsets that are out of range for example_STRING", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_STRING();
 
@@ -637,14 +637,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_variable_length_STRING_array", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_variable_length_STRING_array", async function () {
+    it("should not report issues for a valid example_variable_length_STRING_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_STRING_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -668,14 +668,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_fixed_length_STRING_array", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_fixed_length_STRING_array", async function () {
+    it("should not report issues for a valid example_fixed_length_STRING_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_STRING_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -698,14 +698,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_FLOAT32_VEC2", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_FLOAT32_VEC2", async function () {
+    it("should not report issues for a valid example_FLOAT32_VEC2", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_FLOAT32_VEC2();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -729,14 +729,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_variable_length_UINT32_VEC2_array", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_variable_length_UINT32_VEC2_array", async function () {
+    it("should not report issues for a valid example_variable_length_UINT32_VEC2_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_variable_length_UINT32_VEC2_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(
@@ -760,14 +760,14 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
   describe("issues for example_fixed_length_UINT32_VEC2_array", function () {
     let context: ValidationContext;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       const directory = "specs/data/propertyTables/";
       const resourceResolver =
         ResourceResolvers.createFileResourceResolver(directory);
       context = new ValidationContext(resourceResolver);
     });
 
-    it("should not report issues for a valid example_fixed_length_UINT32_VEC2_array", async function () {
+    it("should not report issues for a valid example_fixed_length_UINT32_VEC2_array", function () {
       const binaryPropertyTable =
         PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_fixed_length_UINT32_VEC2_array();
       BinaryPropertyTableValidator.validateBinaryPropertyTable(

--- a/specs/metadata/BinaryPropertyTableValuesValidationSpec.ts
+++ b/specs/metadata/BinaryPropertyTableValuesValidationSpec.ts
@@ -1,0 +1,267 @@
+import { ResourceResolvers } from "../../src/io/ResourceResolvers";
+
+import { ValidationContext } from "../../src/validation/ValidationContext";
+import { BinaryPropertyTableValidator } from "../../src/validation/metadata/BinaryPropertyTableValidator";
+
+import { PropertyTableTestUtilities } from "./PropertyTableTestUtilities";
+
+// A flag to enable printing all `ValidationResult`
+// instances to the console during the tests.
+const debugLogResults = true;
+
+describe("metadata/BinaryPropertyTableValuesValidationSpec", function () {
+  //==========================================================================
+  //=== example_INT16_SCALAR test cases:
+  // - no issues for valid input
+  // - values out of range for 'min' and 'max' in classProperty
+  //   and in propertyTableProperty
+
+  describe("issues for example_INT16_SCALAR", function () {
+    let context: ValidationContext;
+
+    beforeEach(function () {
+      const directory = "specs/data/propertyTables/";
+      const resourceResolver =
+        ResourceResolvers.createFileResourceResolver(directory);
+      context = new ValidationContext(resourceResolver);
+    });
+
+    it("should not report issues for a valid example_INT16_SCALAR", function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+
+      // For the test: Fill the property with the
+      // values 10 and 12, and set the minimum
+      // to be 10 and the maximum to be 12 in the
+      // class property
+      const classProperty =
+        binaryPropertyTable.metadataClass.properties!["testProperty"];
+      const propertyTableProperty =
+        binaryPropertyTable.propertyTable.properties!["testProperty"];
+      const valuesBufferViewIndex = propertyTableProperty.values;
+      const valuesBufferViewData =
+        binaryPropertyTable.binaryBufferData!.bufferViewsData![
+          valuesBufferViewIndex
+        ];
+      valuesBufferViewData.writeInt16LE(10, 0);
+      valuesBufferViewData.writeInt16LE(12, 2);
+      classProperty.min = 10;
+      classProperty.max = 12;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+
+    it("detects values smaller than the class property minimum for example_INT16_SCALAR", function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+
+      // For the test: Fill the property with the
+      // values 10 and 12, and set the minimum
+      // to be 11 in the class property
+      const classProperty =
+        binaryPropertyTable.metadataClass.properties!["testProperty"];
+      const propertyTableProperty =
+        binaryPropertyTable.propertyTable.properties!["testProperty"];
+      const valuesBufferViewIndex = propertyTableProperty.values;
+      const valuesBufferViewData =
+        binaryPropertyTable.binaryBufferData!.bufferViewsData![
+          valuesBufferViewIndex
+        ];
+      valuesBufferViewData.writeInt16LE(10, 0);
+      valuesBufferViewData.writeInt16LE(12, 2);
+      classProperty.min = 11;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(1);
+      expect(result.get(0).type).toEqual("METADATA_VALUE_NOT_IN_RANGE");
+    });
+
+    it("detects values greater than the class property maximum for example_INT16_SCALAR", function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+
+      // For the test: Fill the property with the
+      // values 10 and 12, and set the minimum
+      // to be 11 in the class property
+      const classProperty =
+        binaryPropertyTable.metadataClass.properties!["testProperty"];
+      const propertyTableProperty =
+        binaryPropertyTable.propertyTable.properties!["testProperty"];
+      const valuesBufferViewIndex = propertyTableProperty.values;
+      const valuesBufferViewData =
+        binaryPropertyTable.binaryBufferData!.bufferViewsData![
+          valuesBufferViewIndex
+        ];
+      valuesBufferViewData.writeInt16LE(10, 0);
+      valuesBufferViewData.writeInt16LE(12, 2);
+      classProperty.max = 11;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(1);
+      expect(result.get(0).type).toEqual("METADATA_VALUE_NOT_IN_RANGE");
+    });
+
+    it("detects values smaller than the property table property minimum for example_INT16_SCALAR", function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+
+      // For the test: Fill the property with the
+      // values 10 and 12, and set the minimum
+      // to be 11 in the class property
+      const classProperty =
+        binaryPropertyTable.metadataClass.properties!["testProperty"];
+      const propertyTableProperty =
+        binaryPropertyTable.propertyTable.properties!["testProperty"];
+      const valuesBufferViewIndex = propertyTableProperty.values;
+      const valuesBufferViewData =
+        binaryPropertyTable.binaryBufferData!.bufferViewsData![
+          valuesBufferViewIndex
+        ];
+      valuesBufferViewData.writeInt16LE(10, 0);
+      valuesBufferViewData.writeInt16LE(12, 2);
+      propertyTableProperty.min = 11;
+      // This should be overridden by the property table property:
+      classProperty.min = 12345;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(1);
+      expect(result.get(0).type).toEqual("METADATA_VALUE_NOT_IN_RANGE");
+    });
+
+    it("detects values greater than the property table property maximum for example_INT16_SCALAR", function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+
+      // For the test: Fill the property with the
+      // values 10 and 12, and set the minimum
+      // to be 11 in the class property
+      const classProperty =
+        binaryPropertyTable.metadataClass.properties!["testProperty"];
+      const propertyTableProperty =
+        binaryPropertyTable.propertyTable.properties!["testProperty"];
+      const valuesBufferViewIndex = propertyTableProperty.values;
+      const valuesBufferViewData =
+        binaryPropertyTable.binaryBufferData!.bufferViewsData![
+          valuesBufferViewIndex
+        ];
+      valuesBufferViewData.writeInt16LE(10, 0);
+      valuesBufferViewData.writeInt16LE(12, 2);
+      propertyTableProperty.max = 11;
+      // This should be overridden by the property table property:
+      classProperty.max = 12345;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(1);
+      expect(result.get(0).type).toEqual("METADATA_VALUE_NOT_IN_RANGE");
+    });
+
+    it("should not report issues for an example_INT16_SCALAR that is in the required range after applying offset", function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+
+      // For the test:
+      // - Fill the property with the values 10 and 12.
+      // Assign an offset of 100 to the class property.
+      // Assign a maximum of 112 to the property table property
+      const classProperty =
+        binaryPropertyTable.metadataClass.properties!["testProperty"];
+      const propertyTableProperty =
+        binaryPropertyTable.propertyTable.properties!["testProperty"];
+      const valuesBufferViewIndex = propertyTableProperty.values;
+      const valuesBufferViewData =
+        binaryPropertyTable.binaryBufferData!.bufferViewsData![
+          valuesBufferViewIndex
+        ];
+      valuesBufferViewData.writeInt16LE(10, 0);
+      valuesBufferViewData.writeInt16LE(12, 2);
+      classProperty.offset = 100;
+      propertyTableProperty.max = 112;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+
+    it("should not report issues for an example_INT16_SCALAR that is in the required range after applying scale", function () {
+      const binaryPropertyTable =
+        PropertyTableTestUtilities.createDefaultBinaryPropertyTable_example_INT16_SCALAR();
+
+      // For the test:
+      // - Fill the property with the values 10 and 12.
+      // Assign an offset of 100 to the class property.
+      // Assign a maximum of 112 to the property table property
+      const classProperty =
+        binaryPropertyTable.metadataClass.properties!["testProperty"];
+      const propertyTableProperty =
+        binaryPropertyTable.propertyTable.properties!["testProperty"];
+      const valuesBufferViewIndex = propertyTableProperty.values;
+      const valuesBufferViewData =
+        binaryPropertyTable.binaryBufferData!.bufferViewsData![
+          valuesBufferViewIndex
+        ];
+      valuesBufferViewData.writeInt16LE(10, 0);
+      valuesBufferViewData.writeInt16LE(12, 2);
+      classProperty.scale = 10;
+      propertyTableProperty.max = 120;
+
+      BinaryPropertyTableValidator.validateBinaryPropertyTable(
+        "test",
+        binaryPropertyTable,
+        context
+      );
+      const result = context.getResult();
+      if (debugLogResults) {
+        console.log(result.toJson());
+      }
+      expect(result.length).toEqual(0);
+    });
+  });
+});

--- a/specs/metadata/PropertyTableTestUtilities.ts
+++ b/specs/metadata/PropertyTableTestUtilities.ts
@@ -1,25 +1,27 @@
+import { BinaryPropertyTable } from "../../src/binary/BinaryPropertyTable";
 import { BinaryPropertyTables } from "../../src/binary/BinaryPropertyTables";
-import { PropertyTableModel } from "../../src/binary/PropertyTableModel";
 
 import { ClassProperty } from "../../src/structure/Metadata/ClassProperty";
 
-import { genericEquals } from "./genericEquals";
-
 /**
- * Test for the `PropertyTableModels` class.
+ * Methods to create `BinaryPropertyTable` instances that are valid,
+ * and contain the data for a single property.
  *
- * These tests just verify the "roundtrip":
- * - They create a `PropertyTableModel` from a single property
- *   and its associated data
- * - They obtain the `MetadataEntityModel` instances from the
- *   property table model
- * - They check whether the elements of the input data and the
- *   values from the entity model are generically equal.
+ * These methods are used in the `BinaryPropertyTableValidationSpec.ts`
+ * to create valid `BinaryPropertyTable` instances, that are then made
+ * invalid in various ways in order to check whether these errors are
+ * detected asvalidation issues.
+ *
+ * @private
  */
-describe("metadata/PropertyTableModelSpec", function () {
-  const epsilon = 0.000001;
-
-  it("correctly represents example_INT16_SCALAR", function () {
+export class PropertyTableTestUtilities {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_INT16_SCALAR(): BinaryPropertyTable {
     const example_INT16_SCALAR: ClassProperty = {
       type: "SCALAR",
       componentType: "INT16",
@@ -40,17 +42,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_variable_length_INT16_SCALAR_array", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_variable_length_INT16_SCALAR_array(): BinaryPropertyTable {
     const example_variable_length_INT16_SCALAR_array: ClassProperty = {
       type: "SCALAR",
       componentType: "INT16",
@@ -75,17 +76,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_fixed_length_INT16_SCALAR_array", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_fixed_length_INT16_SCALAR_array(): BinaryPropertyTable {
     const example_fixed_length_INT16_SCALAR_array: ClassProperty = {
       type: "SCALAR",
       componentType: "INT16",
@@ -111,17 +111,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_BOOLEAN", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_BOOLEAN(): BinaryPropertyTable {
     const example_BOOLEAN: ClassProperty = {
       type: "BOOLEAN",
     };
@@ -141,17 +140,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_variable_length_BOOLEAN_array", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_variable_length_BOOLEAN_array(): BinaryPropertyTable {
     const example_variable_length_BOOLEAN_array: ClassProperty = {
       type: "BOOLEAN",
       array: true,
@@ -175,17 +173,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_fixed_length_BOOLEAN_array", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_fixed_length_BOOLEAN_array(): BinaryPropertyTable {
     const example_fixed_length_BOOLEAN_array: ClassProperty = {
       type: "BOOLEAN",
       array: true,
@@ -209,17 +206,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_STRING", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_STRING(): BinaryPropertyTable {
     const example_STRING: ClassProperty = {
       type: "STRING",
     };
@@ -239,17 +235,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_variable_length_STRING_array", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_variable_length_STRING_array(): BinaryPropertyTable {
     const example_variable_length_STRING_array: ClassProperty = {
       type: "STRING",
       array: true,
@@ -273,17 +268,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_fixed_length_STRING_array", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_fixed_length_STRING_array(): BinaryPropertyTable {
     const example_fixed_length_STRING_array: ClassProperty = {
       type: "STRING",
       array: true,
@@ -308,17 +302,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_FLOAT32_VEC2", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_FLOAT32_VEC2(): BinaryPropertyTable {
     const example_FLOAT32_VEC2: ClassProperty = {
       type: "VEC2",
       componentType: "FLOAT32",
@@ -342,17 +335,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_variable_length_UINT32_VEC2_array", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_variable_length_UINT32_VEC2_array(): BinaryPropertyTable {
     const example_variable_length_UINT32_VEC2_array: ClassProperty = {
       type: "VEC2",
       componentType: "FLOAT32",
@@ -384,17 +376,16 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
+    return binaryPropertyTable;
+  }
 
-  it("correctly represents example_fixed_length_UINT32_VEC2_array", function () {
+  /**
+   * Creates an unspecified valid default `BinaryPropertyTable`, containing
+   * a single property with the type indicated in the method name.
+   *
+   * @returns The `BinaryPropertyTable`
+   */
+  static createDefaultBinaryPropertyTable_example_fixed_length_UINT32_VEC2_array(): BinaryPropertyTable {
     const example_fixed_length_UINT32_VEC2_array: ClassProperty = {
       type: "VEC2",
       componentType: "FLOAT32",
@@ -426,13 +417,6 @@ describe("metadata/PropertyTableModelSpec", function () {
         stringOffsetType,
         undefined
       );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    const count = values.length;
-    for (let i = 0; i < count; i++) {
-      const entity = propertyTableModel.getMetadataEntityModel(i);
-      const expected = values[i];
-      const actual = entity.getPropertyValue("testProperty");
-      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
-    }
-  });
-});
+    return binaryPropertyTable;
+  }
+}

--- a/src/binary/BinaryBuffers.ts
+++ b/src/binary/BinaryBuffers.ts
@@ -52,7 +52,8 @@ export class BinaryBuffers {
     let currentByteOffset = 0;
     for (let i = 0; i < newBufferViewsData.length; i++) {
       const newBufferViewData = newBufferViewsData[i];
-      const requiredPadding = currentByteOffset % alignment;
+      const requiredPadding =
+        (alignment - (currentByteOffset % alignment)) % alignment;
       if (requiredPadding != 0) {
         const paddingBuffer = Buffer.alloc(requiredPadding);
         currentBufferData = Buffer.concat([currentBufferData, paddingBuffer]);

--- a/src/binary/BinaryMetadataEntityModel.ts
+++ b/src/binary/BinaryMetadataEntityModel.ts
@@ -34,13 +34,28 @@ export class BinaryMetadataEntityModel implements MetadataEntityModel {
       const message = `The class does not define a property ${propertyId}`;
       throw new MetadataError(message);
     }
-    const propertyModel = propertyTableModel.getPropertyModel(propertyId);
-    if (!defined(propertyModel)) {
+    const propertyTableProperty =
+      propertyTableModel.getPropertyTableProperty(propertyId);
+    if (!defined(propertyTableProperty)) {
       const message = `The property table does not define a property ${propertyId}`;
       throw new MetadataError(message);
     }
+    const propertyModel = propertyTableModel.getPropertyModel(propertyId);
+    if (!defined(propertyModel)) {
+      const message =
+        `The property table does not ` +
+        `define a property model for ${propertyId}`;
+      throw new MetadataError(message);
+    }
     const value = propertyModel!.getPropertyValue(this._entityIndex);
-    const processedValue = MetadataValues.processValue(classProperty!, value);
+    const offsetOverride = propertyTableProperty!.offset;
+    const scaleOverride = propertyTableProperty!.scale;
+    const processedValue = MetadataValues.processValue(
+      classProperty!,
+      offsetOverride,
+      scaleOverride,
+      value
+    );
     return processedValue;
   }
 

--- a/src/binary/BinaryPropertyTables.ts
+++ b/src/binary/BinaryPropertyTables.ts
@@ -2,7 +2,6 @@ import { defined } from "../base/defined";
 import { defaultValue } from "../base/defaultValue";
 import { DeveloperError } from "../base/DeveloperError";
 
-import { PropertyTableModel } from "./PropertyTableModel";
 import { BinaryPropertyTable } from "./BinaryPropertyTable";
 import { BinaryBufferData } from "./BinaryBufferData";
 import { BinaryBuffers } from "./BinaryBuffers";
@@ -18,7 +17,7 @@ import { PropertyTableProperty } from "../structure/PropertyTableProperty";
 import { MetadataEnum } from "../structure/Metadata/MetadataEnum";
 
 /**
- * Methods to create `PropertyTableModel` instances from individual
+ * Methods to create `BinaryPropertyTable` instances from individual
  * properties and their associated data.
  *
  * Right now, the methods in this class are mainly intended for
@@ -54,37 +53,7 @@ import { MetadataEnum } from "../structure/Metadata/MetadataEnum";
  *
  * @private
  */
-export class PropertyTableModels {
-  /**
-   * Creates a new `PropertyTableModel` from a single `ClassProperty`
-   * and its associated values.
-   *
-   * @param propertyName The name of the property
-   * @param classProperty The actual `ClassProperty`
-   * @param values The values for the property
-   * @returns The `PropertyTableModel`
-   */
-  static createPropertyTableModelFromProperty(
-    propertyName: string,
-    classProperty: ClassProperty,
-    values: any,
-    metadataEnum: MetadataEnum | undefined
-  ): PropertyTableModel {
-    const arrayOffsetType = "UINT32";
-    const stringOffsetType = "UINT32";
-    const binaryPropertyTable =
-      PropertyTableModels.createBinaryPropertyTableFromProperty(
-        propertyName,
-        classProperty,
-        values,
-        arrayOffsetType,
-        stringOffsetType,
-        metadataEnum
-      );
-    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
-    return propertyTableModel;
-  }
-
+export class BinaryPropertyTables {
   /**
    * Creates a (dummy) `MetadataClass` that only contains the given property
    *
@@ -191,7 +160,7 @@ export class PropertyTableModels {
     stringOffsetType: string | undefined,
     bufferViewsData: Buffer[]
   ): PropertyTableProperty {
-    const valuesBuffer = PropertyTableModels.createValuesBuffer(
+    const valuesBuffer = BinaryPropertyTables.createValuesBuffer(
       classProperty,
       schema,
       values
@@ -210,7 +179,7 @@ export class PropertyTableModels {
     const isVariableLengthArray =
       classProperty.array && !defined(classProperty.count);
     if (isVariableLengthArray) {
-      const arrayOffsetBuffer = PropertyTableModels.createArrayOffsetBuffer(
+      const arrayOffsetBuffer = BinaryPropertyTables.createArrayOffsetBuffer(
         values,
         arrayOffsetType
       );
@@ -220,7 +189,7 @@ export class PropertyTableModels {
     }
 
     if (classProperty.type === "STRING") {
-      const stringOffsetBuffer = PropertyTableModels.createStringOffsetBuffer(
+      const stringOffsetBuffer = BinaryPropertyTables.createStringOffsetBuffer(
         values,
         stringOffsetType
       );
@@ -252,11 +221,11 @@ export class PropertyTableModels {
   ): Schema {
     const className = "generatedClass";
     const metadataClass =
-      PropertyTableModels.createMetadataClassFromClassProperty(
+      BinaryPropertyTables.createMetadataClassFromClassProperty(
         propertyName,
         classProperty
       );
-    const schema = PropertyTableModels.createSchemaFromMetadataClass(
+    const schema = BinaryPropertyTables.createSchemaFromMetadataClass(
       className,
       metadataClass
     );
@@ -297,13 +266,13 @@ export class PropertyTableModels {
     stringOffsetType: string | undefined,
     metadataEnum: MetadataEnum | undefined
   ): BinaryPropertyTable {
-    const schema = PropertyTableModels.createSchemaFromClassProperty(
+    const schema = BinaryPropertyTables.createSchemaFromClassProperty(
       propertyName,
       classProperty,
       metadataEnum
     );
     const className = "generatedClass";
-    const binaryPropertyTable = PropertyTableModels.createBinaryPropertyTable(
+    const binaryPropertyTable = BinaryPropertyTables.createBinaryPropertyTable(
       schema,
       className,
       propertyName,
@@ -349,7 +318,7 @@ export class PropertyTableModels {
 
     const createdBufferViewsData: Buffer[] = [];
     const propertyTableProperty =
-      PropertyTableModels.createPropertyTableProperty(
+      BinaryPropertyTables.createPropertyTableProperty(
         classProperty,
         schema,
         values,
@@ -358,7 +327,7 @@ export class PropertyTableModels {
         createdBufferViewsData
       );
     const count = values.length;
-    const propertyTable = PropertyTableModels.createPropertyTableFromProperty(
+    const propertyTable = BinaryPropertyTables.createPropertyTableFromProperty(
       className,
       propertyName,
       count,
@@ -401,8 +370,8 @@ export class PropertyTableModels {
     values: any,
     componentType: string | undefined
   ): Buffer {
-    const buffer = PropertyTableModels.toBuffer(
-      PropertyTableModels.createBufferInternal(values, componentType)
+    const buffer = BinaryPropertyTables.toBuffer(
+      BinaryPropertyTables.createBufferInternal(values, componentType)
     );
     return buffer;
   }
@@ -411,7 +380,7 @@ export class PropertyTableModels {
     values: any,
     componentType: string | undefined
   ): ArrayBuffer {
-    const flatValues = PropertyTableModels.flattenFully(values);
+    const flatValues = BinaryPropertyTables.flattenFully(values);
     switch (componentType) {
       case "INT8":
         return new Int8Array(flatValues).buffer;
@@ -438,25 +407,25 @@ export class PropertyTableModels {
   }
 
   private static createStringBuffer(values: any): Buffer {
-    return PropertyTableModels.toBuffer(
-      PropertyTableModels.createStringBufferInternal(values)
+    return BinaryPropertyTables.toBuffer(
+      BinaryPropertyTables.createStringBufferInternal(values)
     );
   }
 
   private static createStringBufferInternal(inputValues: any): Uint8Array {
-    const values = PropertyTableModels.flattenFully(inputValues);
+    const values = BinaryPropertyTables.flattenFully(inputValues);
     const encoder = new TextEncoder();
     return encoder.encode(values.join(""));
   }
 
   private static createBooleanBuffer(values: any): Buffer {
-    return PropertyTableModels.toBuffer(
-      PropertyTableModels.createBooleanBufferInternal(values)
+    return BinaryPropertyTables.toBuffer(
+      BinaryPropertyTables.createBooleanBufferInternal(values)
     );
   }
 
   private static createBooleanBufferInternal(inputValues: any): Uint8Array {
-    const values = PropertyTableModels.flattenFully(inputValues);
+    const values = BinaryPropertyTables.flattenFully(inputValues);
     const length = Math.ceil(values.length / 8);
     const typedArray = new Uint8Array(length); // Initialized as 0's
     for (let i = 0; i < values.length; ++i) {
@@ -478,7 +447,7 @@ export class PropertyTableModels {
     if (Array.isArray(result)) {
       result = [];
       for (let i = 0; i < values.length; i++) {
-        result = result.concat(PropertyTableModels.flattenFully(values[i]));
+        result = result.concat(BinaryPropertyTables.flattenFully(values[i]));
       }
     }
     return result;
@@ -492,14 +461,14 @@ export class PropertyTableModels {
     const type = classProperty.type;
     const componentType = classProperty.componentType;
     const enumType = classProperty.enumType;
-    const flattenedValues = PropertyTableModels.flatten(values);
+    const flattenedValues = BinaryPropertyTables.flatten(values);
 
     if (type === "STRING") {
-      return PropertyTableModels.createStringBuffer(flattenedValues);
+      return BinaryPropertyTables.createStringBuffer(flattenedValues);
     }
 
     if (type === "BOOLEAN") {
-      return PropertyTableModels.createBooleanBuffer(flattenedValues);
+      return BinaryPropertyTables.createBooleanBuffer(flattenedValues);
     }
 
     if (defined(enumType)) {
@@ -514,7 +483,7 @@ export class PropertyTableModels {
       }
     }
 
-    return PropertyTableModels.createBuffer(flattenedValues, componentType);
+    return BinaryPropertyTables.createBuffer(flattenedValues, componentType);
   }
 
   private static createStringOffsetBuffer(
@@ -522,7 +491,7 @@ export class PropertyTableModels {
     offsetType: string | undefined
   ) {
     const encoder = new TextEncoder();
-    const strings = PropertyTableModels.flattenFully(values);
+    const strings = BinaryPropertyTables.flattenFully(values);
     const length = strings.length;
     const offsets = new Array(length + 1);
     let offset = 0;
@@ -532,7 +501,7 @@ export class PropertyTableModels {
     }
     offsets[length] = offset;
     offsetType = defaultValue(offsetType, "UINT32");
-    return PropertyTableModels.createBuffer(offsets, offsetType);
+    return BinaryPropertyTables.createBuffer(offsets, offsetType);
   }
 
   private static createArrayOffsetBuffer(
@@ -548,6 +517,6 @@ export class PropertyTableModels {
     }
     offsets[length] = offset;
     offsetType = defaultValue(offsetType, "UINT32");
-    return PropertyTableModels.createBuffer(offsets, offsetType);
+    return BinaryPropertyTables.createBuffer(offsets, offsetType);
   }
 }

--- a/src/binary/PropertyModels.ts
+++ b/src/binary/PropertyModels.ts
@@ -1,13 +1,174 @@
 import { defined } from "../base/defined";
+import { defaultValue } from "../base/defaultValue";
 
+import { BinaryPropertyTable } from "./BinaryPropertyTable";
+import { PropertyModel } from "./PropertyModel";
+import { StringPropertyModel } from "./StringPropertyModel";
+import { BooleanPropertyModel } from "./BooleanPropertyModel";
+import { NumericPropertyModel } from "./NumericPropertyModel";
+import { NumericArrayPropertyModel } from "./NumericArrayPropertyModel";
+import { StringArrayPropertyModel } from "./StringArrayPropertyModel";
+import { BooleanArrayPropertyModel } from "./BooleanArrayPropertyModel";
 import { NumericBuffers } from "./NumericBuffers";
 
 /**
- * Internal methods related to `PropertyModel` instances
+ * Methods related to `PropertyModel` instances
  *
  * @private
  */
 export class PropertyModels {
+  /**
+   * Creates a `PropertyModel` for the specified property in
+   * the given `BinaryPropertyTable`.
+   *
+   * This assumes that the input is structurally valid, as
+   * determined with the `BinaryPropertyTableValidator`.
+   *
+   * This will determine the type of the property and access its
+   * associated data (i.e. the required buffer views data) from
+   * the given `BinaryPropertyTable`. For each type of property,
+   * this will return a matching implementation of the
+   * `PropertyModel` interface.
+   *
+   * @param binaryPropertyTable The `BinaryPropertyTable`
+   * @param propertyId The property ID
+   * @returns The `PropertyModel`
+   */
+  static createPropertyModel(
+    binaryPropertyTable: BinaryPropertyTable,
+    propertyId: string
+  ): PropertyModel {
+    // Obtain the `ClassProperty`
+    const metadataClass = binaryPropertyTable.metadataClass;
+    const classProperties = metadataClass.properties;
+    const classProperty = classProperties![propertyId];
+
+    // Obtain the `PropertyTableProperty`
+    const propertyTable = binaryPropertyTable.propertyTable;
+    const propertyTableProperties = propertyTable.properties;
+    const propertyTableProperty = propertyTableProperties![propertyId];
+
+    // Obtain the required buffers from the binary data:
+    const binaryBufferData = binaryPropertyTable.binaryBufferData;
+    const bufferViewsData = binaryBufferData.bufferViewsData;
+
+    // Obtain the `values` buffer view data
+    const valuesBufferViewIndex = propertyTableProperty.values;
+    const valuesBufferViewData = bufferViewsData[valuesBufferViewIndex];
+
+    // Obtain the `arrayOffsets` buffer view data
+    const arrayOffsetsBufferViewIndex = propertyTableProperty.arrayOffsets;
+    let arrayOffsetsBufferViewData = undefined;
+    if (defined(arrayOffsetsBufferViewIndex)) {
+      arrayOffsetsBufferViewData =
+        bufferViewsData[arrayOffsetsBufferViewIndex!];
+    }
+    const arrayOffsetType = defaultValue(
+      propertyTableProperty.arrayOffsetType,
+      "UINT32"
+    );
+
+    // Obtain the `stringOffsets` buffer view data
+    const stringOffsetsBufferViewIndex = propertyTableProperty.stringOffsets;
+    let stringOffsetsBufferViewData = undefined;
+    if (defined(stringOffsetsBufferViewIndex)) {
+      stringOffsetsBufferViewData =
+        bufferViewsData[stringOffsetsBufferViewIndex!];
+    }
+    const stringOffsetType = defaultValue(
+      propertyTableProperty.stringOffsetType,
+      "UINT32"
+    );
+
+    // Determine the `enumValueType` of the property
+    const enumType = classProperty.enumType;
+    let enumValueType = undefined;
+    if (defined(enumType)) {
+      const enumValueTypes = binaryPropertyTable.enumValueTypes;
+      enumValueType = defaultValue(enumValueTypes[enumType!], "UINT16");
+    }
+
+    // Create the `PropertyModel` implementation that matches
+    // the type of the property
+    const type = classProperty.type;
+    const componentType = classProperty.componentType;
+    const count = classProperty.count;
+    const isArray = classProperty.array === true;
+    if (isArray) {
+      if (type === "STRING") {
+        const propertyModel = new StringArrayPropertyModel(
+          valuesBufferViewData,
+          arrayOffsetsBufferViewData,
+          arrayOffsetType,
+          stringOffsetsBufferViewData!,
+          stringOffsetType,
+          count
+        );
+        return propertyModel;
+      }
+      if (type === "BOOLEAN") {
+        const propertyModel = new BooleanArrayPropertyModel(
+          valuesBufferViewData,
+          arrayOffsetsBufferViewData,
+          arrayOffsetType,
+          count
+        );
+        return propertyModel;
+      }
+      if (type === "ENUM") {
+        const propertyModel = new NumericArrayPropertyModel(
+          type,
+          valuesBufferViewData,
+          enumValueType!,
+          arrayOffsetsBufferViewData,
+          arrayOffsetType,
+          count
+        );
+        return propertyModel;
+      }
+      // The 'type' must be a numeric (array) type here
+      const propertyModel = new NumericArrayPropertyModel(
+        type,
+        valuesBufferViewData,
+        componentType!,
+        arrayOffsetsBufferViewData,
+        arrayOffsetType,
+        count
+      );
+      return propertyModel;
+    }
+
+    // The property must be a non-array property here:
+    if (type === "STRING") {
+      const propertyModel = new StringPropertyModel(
+        valuesBufferViewData,
+        stringOffsetsBufferViewData!,
+        stringOffsetType
+      );
+      return propertyModel;
+    }
+    if (type === "BOOLEAN") {
+      const propertyModel = new BooleanPropertyModel(valuesBufferViewData);
+      return propertyModel;
+    }
+    if (type === "ENUM") {
+      const propertyModel = new NumericPropertyModel(
+        type,
+        valuesBufferViewData,
+        enumValueType!
+      );
+      return propertyModel;
+    }
+
+    // The property must be a (non-array) numeric property here
+    const propertyModel = new NumericPropertyModel(
+      type,
+      valuesBufferViewData,
+      componentType!
+    );
+    return propertyModel;
+  }
+
   /**
    * Returns the 'slice' information that is given by an offsets
    * buffer or a fixed number.

--- a/src/binary/PropertyTableModel.ts
+++ b/src/binary/PropertyTableModel.ts
@@ -10,6 +10,7 @@ import { MetadataError } from "../metadata/MetadataError";
 
 import { ClassProperty } from "../../src/structure/Metadata/ClassProperty";
 import { MetadataEntityModel } from "../metadata/MetadataEntityModel";
+import { PropertyTableProperty } from "../structure/PropertyTableProperty";
 
 /**
  * Implementation of a model for a property table that is backed
@@ -95,6 +96,23 @@ export class PropertyTableModel {
     const metadataClass = binaryPropertyTable.metadataClass;
     const classProperties = defaultValue(metadataClass.properties, {});
     return classProperties[propertyId];
+  }
+
+  /**
+   * Returns the `PropertyTableProperty` that defines the structure of the
+   * property with the given ID, or `undefined` if this table was
+   * created for a `PropertyTable` that does not define this property.
+   *
+   * @param propertyId The property ID
+   * @returns The `PropertyTableProperty`
+   */
+  getPropertyTableProperty(
+    propertyId: string
+  ): PropertyTableProperty | undefined {
+    const binaryPropertyTable = this._binaryPropertyTable;
+    const propertyTable = binaryPropertyTable.propertyTable;
+    const propertyTableProperties = defaultValue(propertyTable.properties, {});
+    return propertyTableProperties[propertyId];
   }
 
   /**

--- a/src/binaryMetadataDemos.ts
+++ b/src/binaryMetadataDemos.ts
@@ -1,6 +1,7 @@
 import { ClassProperty } from "./structure/Metadata/ClassProperty";
 
-import { PropertyTableModels } from "./binary/PropertyTableModels";
+import { BinaryPropertyTables } from "./binary/BinaryPropertyTables";
+import { PropertyTableModel } from "./binary/PropertyTableModel";
 
 function runPropertyTableModelTest(
   name: string,
@@ -8,14 +9,18 @@ function runPropertyTableModelTest(
   propertyValues: any
 ) {
   const count = propertyValues.length;
-  const propertyTableModel =
-    PropertyTableModels.createPropertyTableModelFromProperty(
+  const arrayOffsetType = "UINT32";
+  const stringOffsetType = "UINT32";
+  const binaryPropertyTable =
+    BinaryPropertyTables.createBinaryPropertyTableFromProperty(
       "testProperty",
       classProperty,
       propertyValues,
+      arrayOffsetType,
+      stringOffsetType,
       count
     );
-
+  const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
   console.log("For " + name);
   console.log("  Original values: " + JSON.stringify(propertyValues));
   for (let i = 0; i < count; i++) {

--- a/src/issues/MetadataValidationIssues.ts
+++ b/src/issues/MetadataValidationIssues.ts
@@ -3,7 +3,7 @@ import { ValidationIssueSeverity } from "../validation/ValidationIssueSeverity";
 
 /**
  * Methods to create `ValidationIssue` instances that describe
- * issues related to (binary) metadata)
+ * issues related to metadata
  */
 export class MetadataValidationIssues {
   static METADATA_INVALID_SIZE(path: string, message: string) {
@@ -20,6 +20,42 @@ export class MetadataValidationIssues {
   }
   static METADATA_INVALID_OFFSETS(path: string, message: string) {
     const type = "METADATA_INVALID_OFFSETS";
+    const severity = ValidationIssueSeverity.ERROR;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+  static METADATA_VALUE_NOT_IN_RANGE(path: string, message: string) {
+    const type = "METADATA_VALUE_NOT_IN_RANGE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  static METADATA_VALUE_REQUIRED_BUT_MISSING(
+    path: string,
+    propertyName: string
+  ) {
+    const type = "METADATA_VALUE_REQUIRED_BUT_MISSING";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The property '${propertyName}' is 'required', but ` +
+      `no value has been given`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+  static METADATA_SEMANTIC_UNKNOWN(
+    path: string,
+    propertyName: string,
+    semantic: string
+  ) {
+    const type = "METADATA_SEMANTIC_UNKNOWN";
+    const severity = ValidationIssueSeverity.WARNING;
+    const message = `The property '${propertyName}' has unknown semantic '${semantic}'`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+  static METADATA_SEMANTIC_INVALID(path: string, message: string) {
+    const type = "METADATA_SEMANTIC_INVALID";
     const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;

--- a/src/issues/SemanticValidationIssues.ts
+++ b/src/issues/SemanticValidationIssues.ts
@@ -245,19 +245,6 @@ export class SemanticValidationIssues {
     return issue;
   }
 
-  static METADATA_VALUE_REQUIRED_BUT_MISSING(
-    path: string,
-    propertyName: string
-  ) {
-    const type = "METADATA_VALUE_REQUIRED_BUT_MISSING";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The property '${propertyName}' is 'required', but ` +
-      `no value has been given`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
   static TEMPLATE_URI_INVALID_VARIABLE_NAME(
     path: string,
     variableName: string,
@@ -353,23 +340,6 @@ export class SemanticValidationIssues {
     const type = "EXTENSION_NOT_SUPPORTED";
     const severity = ValidationIssueSeverity.WARNING;
     const message = `The extension '${extensionName}' was used, but is not supported`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-  static METADATA_SEMANTIC_UNKNOWN(
-    path: string,
-    propertyName: string,
-    semantic: string
-  ) {
-    const type = "METADATA_SEMANTIC_UNKNOWN";
-    const severity = ValidationIssueSeverity.WARNING;
-    const message = `The property '${propertyName}' has unknown semantic '${semantic}'`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-  static METADATA_SEMANTIC_INVALID(path: string, message: string) {
-    const type = "METADATA_SEMANTIC_INVALID";
-    const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }

--- a/src/metadata/DefaultMetadataEntityModel.ts
+++ b/src/metadata/DefaultMetadataEntityModel.ts
@@ -42,7 +42,7 @@ export class DefaultMetadataEntityModel implements MetadataEntityModel {
       );
     }
     const value = this._json[propertyId];
-    return MetadataValues.processValue(property, value);
+    return MetadataValues.processValue(property, undefined, undefined, value);
   }
 
   getPropertyValueBySemantic(semantic: string): any {

--- a/src/metadata/MetadataValues.ts
+++ b/src/metadata/MetadataValues.ts
@@ -28,10 +28,21 @@ export class MetadataValues {
    * with the value.
    *
    * @param classProperty The `ClassProperty`
+   * @param offsetOverride: An optional override for the
+   * `offset` of the `ClassProperty`. If this is defined, then
+   * it will be used instead of the one from the class property.
+   * @param scaleOverride: An optional override for the
+   * `scale` of the `ClassProperty`. If this is defined, then
+   * it will be used instead of the one from the class property.
    * @param value The value
    * @returns The processed value
    */
-  static processValue(classProperty: ClassProperty, value: any): any {
+  static processValue(
+    classProperty: ClassProperty,
+    offsetOverride: any,
+    scaleOverride: any,
+    value: any
+  ): any {
     const noData = classProperty.noData;
     const defaultValue = classProperty.default;
     if (defined(noData)) {
@@ -48,8 +59,10 @@ export class MetadataValues {
       const componentType = classProperty.componentType;
       value = MetadataValues.normalize(value, componentType);
     }
-    const offset = classProperty.offset;
-    const scale = classProperty.scale;
+    const offset = defined(offsetOverride)
+      ? offsetOverride
+      : classProperty.offset;
+    const scale = defined(scaleOverride) ? scaleOverride : classProperty.scale;
     value = MetadataValues.transform(value, offset, scale);
     return value;
   }

--- a/src/validation/metadata/BinaryPropertyTableValidator.ts
+++ b/src/validation/metadata/BinaryPropertyTableValidator.ts
@@ -12,6 +12,7 @@ import { MetadataTypes } from "../../metadata/MetadataTypes";
 import { ClassProperty } from "../../structure/Metadata/ClassProperty";
 
 import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
+import { BinaryPropertyTableValuesValidator } from "./BinaryPropertyTableValuesValidator";
 
 /**
  * A class for validations related to BinaryPropertyTable objects.
@@ -53,6 +54,21 @@ export class BinaryPropertyTableValidator {
         result = false;
       }
     }
+
+    // Only if the basic validity checks passed, perform
+    // the validation of the metadata VALUES
+    if (result) {
+      if (
+        !BinaryPropertyTableValuesValidator.validateBinaryPropertyTableValues(
+          path,
+          binaryPropertyTable,
+          context
+        )
+      ) {
+        result = true;
+      }
+    }
+
     return result;
   }
 

--- a/src/validation/metadata/BinaryPropertyTableValidator.ts
+++ b/src/validation/metadata/BinaryPropertyTableValidator.ts
@@ -850,7 +850,7 @@ export class BinaryPropertyTableValidator {
     }
 
     // For BOOLEAN properties, the number of bytes is given
-    // by the number
+    // by ceil(numValues/8).
     if (type === "BOOLEAN") {
       const message =
         `The 'values' buffer view of property '${propertyId}' ` +

--- a/src/validation/metadata/BinaryPropertyTableValuesValidator.ts
+++ b/src/validation/metadata/BinaryPropertyTableValuesValidator.ts
@@ -1,0 +1,213 @@
+import { defined } from "../../base/defined";
+import { defaultValue } from "../../base/defaultValue";
+
+import { ValidationContext } from "./../ValidationContext";
+
+import { BinaryPropertyTable } from "../../binary/BinaryPropertyTable";
+
+import { ClassProperty } from "../../structure/Metadata/ClassProperty";
+
+import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
+import { PropertyTableModel } from "../../binary/PropertyTableModel";
+
+/**
+ * A class for the validation of values that are stored
+ * in binary property tables.
+ *
+ * The methods in this class assume that the structural
+ * validity of the input objects has already been checked
+ * by a `PropertyTableValidator` and a
+ * `BinaryPropertyTableValidator`.
+ *
+ * @private
+ */
+export class BinaryPropertyTableValuesValidator {
+  /**
+   * Performs the validation to ensure that the given
+   * `BinaryPropertyTable` contains valid values.
+   *
+   * @param path The path for the `ValidationIssue` instances
+   * @param binaryPropertyTable The object to validate
+   * @param context The `ValidationContext` that any issues will be added to
+   * @returns Whether the values in the object have been valid
+   */
+  static validateBinaryPropertyTableValues(
+    path: string,
+    binaryPropertyTable: BinaryPropertyTable,
+    context: ValidationContext
+  ): boolean {
+    let result = true;
+
+    const metadataClass = binaryPropertyTable.metadataClass;
+    const classProperties = defaultValue(metadataClass.properties, {});
+
+    for (const propertyId of Object.keys(classProperties)) {
+      const classProperty = classProperties[propertyId];
+      const propertyPath = path + "/properties/" + propertyId;
+      if (
+        !BinaryPropertyTableValuesValidator.validateBinaryPropertyTablePropertyValues(
+          propertyPath,
+          propertyId,
+          classProperty,
+          binaryPropertyTable,
+          context
+        )
+      ) {
+        result = false;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Validate the values of a single property of a `BinaryPropertyTable`
+   *
+   * @param path The path of the `PropertyTablePropery`, for
+   * `ValidationIssue` instances
+   * @param propertyId The property ID
+   * @param classProperty The `ClassProperty`
+   * @param binaryPropertyTable The `BinaryPropertyTable`
+   * @param context The `ValidationContext`
+   * @returns Whether the property is valid
+   */
+  private static validateBinaryPropertyTablePropertyValues(
+    path: string,
+    propertyId: string,
+    classProperty: ClassProperty,
+    binaryPropertyTable: BinaryPropertyTable,
+    context: ValidationContext
+  ): boolean {
+    let result = true;
+
+    const propertyTable = binaryPropertyTable.propertyTable;
+    const propertyTableCount = propertyTable.count;
+
+    const propertyTableProperties = defaultValue(propertyTable.properties, {});
+    const propertyTablePropertry = propertyTableProperties[propertyId];
+
+    const propertyTableModel = new PropertyTableModel(binaryPropertyTable);
+
+    // Validate each property value
+    for (let index = 0; index < propertyTableCount; index++) {
+      const metadataEntityModel =
+        propertyTableModel.getMetadataEntityModel(index);
+      const propertyValue = metadataEntityModel.getPropertyValue(propertyId);
+
+      if (defined(propertyTablePropertry.min)) {
+        // If the property itself defines a minimum (overriding
+        // the minimum from the classProperty), then validate
+        // that the value is greater than or equal to that
+        if (
+          BinaryPropertyTableValuesValidator.genericLessThan(
+            propertyValue,
+            propertyTablePropertry.min!
+          )
+        ) {
+          const message =
+            `Property table property ${propertyId} defines ` +
+            `a minimum of ${propertyTablePropertry.min}, but the ` +
+            `value at index ${index} is ${propertyValue}`;
+          const issue = MetadataValidationIssues.METADATA_VALUE_NOT_IN_RANGE(
+            path,
+            message
+          );
+          context.addIssue(issue);
+          result = false;
+        }
+      } else if (defined(classProperty.min)) {
+        // If the classProperty defines a minimum, then validate
+        // that the value is greater than or equal to that
+        if (
+          BinaryPropertyTableValuesValidator.genericLessThan(
+            propertyValue,
+            classProperty.min!
+          )
+        ) {
+          const message =
+            `For property ${propertyId}, the schema defines ` +
+            `a minimum of ${classProperty.min}, but the value in the property ` +
+            `table at index ${index} is ${propertyValue}`;
+          const issue = MetadataValidationIssues.METADATA_VALUE_NOT_IN_RANGE(
+            path,
+            message
+          );
+          context.addIssue(issue);
+          result = false;
+        }
+      }
+
+      if (defined(propertyTablePropertry.max)) {
+        // If the property itself defines a maximum (overriding
+        // the maximum from the classProperty), then validate
+        // that the value is less than or equal to that
+        if (
+          BinaryPropertyTableValuesValidator.genericGreaterThan(
+            propertyValue,
+            propertyTablePropertry.max!
+          )
+        ) {
+          const message =
+            `Property table property ${propertyId} defines ` +
+            `a maximum of ${propertyTablePropertry.max}, but the ` +
+            `value at index ${index} is ${propertyValue}`;
+          const issue = MetadataValidationIssues.METADATA_VALUE_NOT_IN_RANGE(
+            path,
+            message
+          );
+          context.addIssue(issue);
+          result = false;
+        }
+      } else if (defined(classProperty.max)) {
+        // If the classProperty defines a maximum, then validate
+        // that the value is less than or equal to that
+        if (
+          BinaryPropertyTableValuesValidator.genericGreaterThan(
+            propertyValue,
+            classProperty.max!
+          )
+        ) {
+          const message =
+            `For property ${propertyId}, the schema defines ` +
+            `a maximum of ${classProperty.max}, but the value in the property ` +
+            `table at index ${index} is ${propertyValue}`;
+          const issue = MetadataValidationIssues.METADATA_VALUE_NOT_IN_RANGE(
+            path,
+            message
+          );
+          context.addIssue(issue);
+          result = false;
+        }
+      }
+    }
+    return result;
+  }
+
+  private static genericLessThan(a: any, b: any): boolean {
+    if (Array.isArray(a) && Array.isArray(b)) {
+      for (let i = 0; i < a.length; ++i) {
+        if (a[i] >= b[i]) {
+          return false;
+        }
+      }
+      return true;
+    }
+    if (typeof a === "number" && typeof b == "number") {
+      return Number(a) < Number(b);
+    }
+    return false;
+  }
+  private static genericGreaterThan(a: any, b: any): boolean {
+    if (Array.isArray(a) && Array.isArray(b)) {
+      for (let i = 0; i < a.length; ++i) {
+        if (a[i] <= b[i]) {
+          return false;
+        }
+      }
+      return true;
+    }
+    if (typeof a === "number" && typeof b == "number") {
+      return Number(a) > Number(b);
+    }
+    return false;
+  }
+}

--- a/src/validation/metadata/ClassPropertySemanticsValidator.ts
+++ b/src/validation/metadata/ClassPropertySemanticsValidator.ts
@@ -6,6 +6,7 @@ import { ValidationContext } from "./../ValidationContext";
 import { ClassProperty } from "../../structure/Metadata/ClassProperty";
 
 import { SemanticValidationIssues } from "../../issues/SemanticValidationIssues";
+import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
 
 /**
  * A class for validations of the `semantic` values of
@@ -83,7 +84,7 @@ export class ClassPropertySemanticsValidator {
           semantic!
         );
       if (!defined(semanticMatcher)) {
-        const issue = SemanticValidationIssues.METADATA_SEMANTIC_UNKNOWN(
+        const issue = MetadataValidationIssues.METADATA_SEMANTIC_UNKNOWN(
           propertyPath,
           propertyName,
           semantic!
@@ -146,7 +147,7 @@ export class ClassPropertySemanticsValidator {
         `Property '${propertyName} has semantic '${semantic}', ` +
         `which requires type '${semanticMatcher.type}', but the ` +
         `property has type '${property.type}'`;
-      const issue = SemanticValidationIssues.METADATA_SEMANTIC_INVALID(
+      const issue = MetadataValidationIssues.METADATA_SEMANTIC_INVALID(
         propertyPath,
         message
       );
@@ -163,7 +164,7 @@ export class ClassPropertySemanticsValidator {
           `which requires the component type to match ` +
           `'${semanticMatcher.componentType}', but the ` +
           `property has component type '${componentType}'`;
-        const issue = SemanticValidationIssues.METADATA_SEMANTIC_INVALID(
+        const issue = MetadataValidationIssues.METADATA_SEMANTIC_INVALID(
           propertyPath,
           message
         );
@@ -178,7 +179,7 @@ export class ClassPropertySemanticsValidator {
         `Property '${propertyName} has semantic '${semantic}', ` +
         `which requires the 'array' property to be '${matcherArray}' ` +
         `but the 'array' property is '${property.array}'`;
-      const issue = SemanticValidationIssues.METADATA_SEMANTIC_INVALID(
+      const issue = MetadataValidationIssues.METADATA_SEMANTIC_INVALID(
         propertyPath,
         message
       );
@@ -192,7 +193,7 @@ export class ClassPropertySemanticsValidator {
           `Property '${propertyName} has semantic '${semantic}', which ` +
           `requires the 'count' property to be '${semanticMatcher.count}' ` +
           `but the 'count' property is '${property.count}'`;
-        const issue = SemanticValidationIssues.METADATA_SEMANTIC_INVALID(
+        const issue = MetadataValidationIssues.METADATA_SEMANTIC_INVALID(
           propertyPath,
           message
         );
@@ -208,7 +209,7 @@ export class ClassPropertySemanticsValidator {
         `Property '${propertyName} has semantic '${semantic}', which ` +
         `requires the 'normalized' property to be '${matcherNormalized}' ` +
         `but the 'normalized' property is '${property.normalized}'`;
-      const issue = SemanticValidationIssues.METADATA_SEMANTIC_INVALID(
+      const issue = MetadataValidationIssues.METADATA_SEMANTIC_INVALID(
         propertyPath,
         message
       );
@@ -223,7 +224,7 @@ export class ClassPropertySemanticsValidator {
         `Property '${propertyName} has semantic '${semantic}', ` +
         `which requires enumType '${semanticMatcher.enumType}', but the ` +
         `property has enumType '${property.enumType}'`;
-      const issue = SemanticValidationIssues.METADATA_SEMANTIC_INVALID(
+      const issue = MetadataValidationIssues.METADATA_SEMANTIC_INVALID(
         propertyPath,
         message
       );

--- a/src/validation/metadata/MetadataStructureValidator.ts
+++ b/src/validation/metadata/MetadataStructureValidator.ts
@@ -7,7 +7,7 @@ import { BasicValidator } from "./../BasicValidator";
 import { Schema } from "../../structure/Metadata/Schema";
 
 import { StructureValidationIssues } from "../../issues/StructureValidationIssues";
-import { SemanticValidationIssues } from "../../issues/SemanticValidationIssues";
+import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
 
 /**
  * A class for validations related to instance definitions of
@@ -133,7 +133,7 @@ export class MetadataStructureValidator {
         if (!defined(propertyValue)) {
           if (classProperty.required) {
             const issue =
-              SemanticValidationIssues.METADATA_VALUE_REQUIRED_BUT_MISSING(
+              MetadataValidationIssues.METADATA_VALUE_REQUIRED_BUT_MISSING(
                 path,
                 classPropertyName
               );


### PR DESCRIPTION
The [Metadata validation PR](https://github.com/CesiumGS/3d-tiles-validator/pull/236) contained basic validation of _binary_ metdata from property tables. As mentioned in the [last comment there](https://github.com/CesiumGS/3d-tiles-validator/pull/236#issuecomment-1293703652), some aspecs of the binary data had not yet been validated, and some aspects of the existing validation had not yet been covered by spec-tests. This PR extends the current state in this regard. Further details will be added here via comments. 