### PR TITLE
Improve validation issue consistency.

### DIFF
--- a/specs/MetadataSchemaValidationSpec.ts
+++ b/specs/MetadataSchemaValidationSpec.ts
@@ -71,7 +71,7 @@ describe("Metadata schema validation", function () {
     );
     expect(result.length).toEqual(1);
     expect(result.get(0).type).toEqual(
-      "CLASS_PROPERTY_COMPONENT_TYPE_WITH_INVALID_TYPE"
+      "CLASS_PROPERTY_COMPONENT_TYPE_FOR_NON_NUMERIC_TYPE"
     );
   });
 
@@ -128,7 +128,7 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyDefaultWithRequired.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_TYPE_ERROR");
+    expect(result.get(0).type).toEqual("CLASS_PROPERTY_INCONSISTENT");
   });
 
   it("detects issues in metadataClassPropertyDescriptionInvalidType", async function () {
@@ -188,9 +188,7 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyMaxForNonNumericType.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual(
-      "CLASS_PROPERTY_MIN_MAX_FOR_NON_NUMERIC_TYPE"
-    );
+    expect(result.get(0).type).toEqual("METADATA_MIN_MAX_FOR_NON_NUMERIC_TYPE");
   });
 
   it("detects issues in metadataClassPropertyMinForNonNumericType", async function () {
@@ -198,9 +196,7 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyMinForNonNumericType.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual(
-      "CLASS_PROPERTY_MIN_MAX_FOR_NON_NUMERIC_TYPE"
-    );
+    expect(result.get(0).type).toEqual("METADATA_MIN_MAX_FOR_NON_NUMERIC_TYPE");
   });
 
   it("detects issues in metadataClassPropertyMinForVariableLengthArray", async function () {
@@ -208,7 +204,9 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyMinForVariableLengthArray.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_TYPE_ERROR");
+    expect(result.get(0).type).toEqual(
+      "METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY"
+    );
   });
 
   it("detects issues in metadataClassPropertyNameInvalidType", async function () {
@@ -224,7 +222,7 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyNoDataForBoolean.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_TYPE_ERROR");
+    expect(result.get(0).type).toEqual("CLASS_PROPERTY_INCONSISTENT");
   });
 
   it("detects issues in metadataClassPropertyNoDataInvalidEnumValueName", async function () {
@@ -232,7 +230,9 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyNoDataInvalidEnumValueName.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_ENUM_VALUE_NOT_FOUND");
+    expect(result.get(0).type).toEqual(
+      "CLASS_PROPERTY_ENUM_VALUE_NAME_NOT_FOUND"
+    );
   });
 
   it("detects issues in metadataClassPropertyNoDataInvalidEnumValueNames", async function () {
@@ -240,7 +240,9 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyNoDataInvalidEnumValueNames.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_ENUM_VALUE_NOT_FOUND");
+    expect(result.get(0).type).toEqual(
+      "CLASS_PROPERTY_ENUM_VALUE_NAME_NOT_FOUND"
+    );
   });
 
   it("detects issues in metadataClassPropertyNoDataTypeMismatchA", async function () {
@@ -272,7 +274,7 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyNoDataWithRequired.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_TYPE_ERROR");
+    expect(result.get(0).type).toEqual("CLASS_PROPERTY_INCONSISTENT");
   });
 
   it("detects issues in metadataClassPropertyNormalizedForNonIntegerComponentType", async function () {
@@ -309,7 +311,7 @@ describe("Metadata schema validation", function () {
     );
     expect(result.length).toEqual(1);
     expect(result.get(0).type).toEqual(
-      "CLASS_PROPERTY_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE"
+      "METADATA_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE"
     );
   });
 
@@ -319,7 +321,7 @@ describe("Metadata schema validation", function () {
     );
     expect(result.length).toEqual(1);
     expect(result.get(0).type).toEqual(
-      "CLASS_PROPERTY_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE"
+      "METADATA_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE"
     );
   });
 
@@ -328,7 +330,9 @@ describe("Metadata schema validation", function () {
       "specs/data/schemas/metadataClassPropertyOffsetForVariableLengthArray.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_TYPE_ERROR");
+    expect(result.get(0).type).toEqual(
+      "METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY"
+    );
   });
 
   it("detects issues in metadataClassPropertyOffsetTypeMismatchA", async function () {
@@ -401,7 +405,7 @@ describe("Metadata schema validation", function () {
     );
     expect(result.length).toEqual(1);
     expect(result.get(0).type).toEqual(
-      "CLASS_PROPERTY_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE"
+      "METADATA_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE"
     );
   });
 
@@ -411,7 +415,7 @@ describe("Metadata schema validation", function () {
     );
     expect(result.length).toEqual(1);
     expect(result.get(0).type).toEqual(
-      "CLASS_PROPERTY_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE"
+      "METADATA_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE"
     );
   });
 

--- a/specs/TilesetValidationSpec.ts
+++ b/specs/TilesetValidationSpec.ts
@@ -60,12 +60,12 @@ describe("Tileset validation", function () {
       "specs/data/tilesets/boundingVolumeRegionArrayElementsOutOfRange.json"
     );
     expect(result.length).toEqual(6);
-    expect(result.get(0).type).toEqual("BOUNDING_VOLUME_INCONSISTENT");
-    expect(result.get(1).type).toEqual("BOUNDING_VOLUME_INCONSISTENT");
-    expect(result.get(2).type).toEqual("BOUNDING_VOLUME_INCONSISTENT");
-    expect(result.get(3).type).toEqual("BOUNDING_VOLUME_INCONSISTENT");
-    expect(result.get(4).type).toEqual("BOUNDING_VOLUME_INCONSISTENT");
-    expect(result.get(5).type).toEqual("BOUNDING_VOLUME_INCONSISTENT");
+    expect(result.get(0).type).toEqual("BOUNDING_VOLUME_INVALID");
+    expect(result.get(1).type).toEqual("BOUNDING_VOLUME_INVALID");
+    expect(result.get(2).type).toEqual("BOUNDING_VOLUME_INVALID");
+    expect(result.get(3).type).toEqual("BOUNDING_VOLUME_INVALID");
+    expect(result.get(4).type).toEqual("BOUNDING_VOLUME_INVALID");
+    expect(result.get(5).type).toEqual("BOUNDING_VOLUME_INVALID");
   });
 
   it("detects issues in boundingVolumeRegionArrayInvalidElementType", async function () {
@@ -87,7 +87,7 @@ describe("Tileset validation", function () {
       "specs/data/tilesets/boundingVolumeSphereArrayElementOutOfRange.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("BOUNDING_VOLUME_INCONSISTENT");
+    expect(result.get(0).type).toEqual("BOUNDING_VOLUME_INVALID");
   });
 
   it("detects issues in boundingVolumeSphereArrayInvalidElementType", async function () {
@@ -401,7 +401,7 @@ describe("Tileset validation", function () {
       "specs/data/tilesets/tileContentBoundingVolumeNotInTileBoundingVolume.json"
     );
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("BOUNDING_VOLUME_INCONSISTENT");
+    expect(result.get(0).type).toEqual("BOUNDING_VOLUMES_INCONSISTENT");
   });
 
   it("detects issues in tileContentGroupInvalidIndex", async function () {
@@ -473,8 +473,8 @@ describe("Tileset validation", function () {
       "specs/data/tilesets/tileGeometricErrorNotSmallerThanParentGeometricError.json"
     );
     expect(result.length).toEqual(2);
-    expect(result.get(0).type).toEqual("TILE_GEOMETRIC_ERROR_INCONSISTENT");
-    expect(result.get(1).type).toEqual("TILE_GEOMETRIC_ERROR_INCONSISTENT");
+    expect(result.get(0).type).toEqual("TILE_GEOMETRIC_ERRORS_INCONSISTENT");
+    expect(result.get(1).type).toEqual("TILE_GEOMETRIC_ERRORS_INCONSISTENT");
   });
 
   it("detects issues in tileInvalidType", async function () {

--- a/specs/metadata/BinaryPropertyTableValidationSpec.ts
+++ b/specs/metadata/BinaryPropertyTableValidationSpec.ts
@@ -88,7 +88,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
   });
 
@@ -174,7 +174,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
 
     it("detects descending arrayOffsets for example_variable_length_INT16_SCALAR_array", function () {
@@ -233,7 +233,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
   });
 
@@ -288,7 +288,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
   });
 
@@ -362,7 +362,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
   });
 
@@ -424,7 +424,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
   });
 
@@ -479,7 +479,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
   });
 
@@ -565,7 +565,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
 
     it("detects descending stringOffsets for example_STRING", function () {
@@ -624,7 +624,7 @@ describe("metadata/BinaryPropertyTableValidationSpec", function () {
         console.log(result.toJson());
       }
       expect(result.length).toEqual(1);
-      expect(result.get(0).type).toEqual("METADATA_INVALID_SIZE");
+      expect(result.get(0).type).toEqual("METADATA_INVALID_LENGTH");
     });
   });
 

--- a/specs/metadata/PropertyTableValidationSpec.ts
+++ b/specs/metadata/PropertyTableValidationSpec.ts
@@ -345,7 +345,9 @@ describe("metadata/PropertyTableValidationSpec", function () {
     );
     const result = context.getResult();
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_TYPE_ERROR");
+    expect(result.get(0).type).toEqual(
+      "METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY"
+    );
   });
   it("detects issues in propertyVariableLengthArrayWithOffset", async function () {
     const inputData = await readJsonUnchecked(
@@ -362,7 +364,9 @@ describe("metadata/PropertyTableValidationSpec", function () {
     );
     const result = context.getResult();
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CLASS_PROPERTY_TYPE_ERROR");
+    expect(result.get(0).type).toEqual(
+      "METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY"
+    );
   });
 
   it("detects issues in propertyVariableLengthArrayWithoutArrayOffsets", async function () {

--- a/src/issues/ContentValidationIssues.ts
+++ b/src/issues/ContentValidationIssues.ts
@@ -11,7 +11,7 @@ export class ContentValidationIssues {
   /**
    * Creates a new content `ValidationIssue` that summarizes the
    * given `ValidationResult`, or `undefined` if the given result
-   * does not contain errors or warnings.
+   * is empty.
    *
    * If the given result contains errors, then a
    * `CONTENT_VALIDATION_ERROR` will be created, with the

--- a/src/issues/MetadataValidationIssues.ts
+++ b/src/issues/MetadataValidationIssues.ts
@@ -6,30 +6,92 @@ import { ValidationIssueSeverity } from "../validation/ValidationIssueSeverity";
  * issues related to metadata
  */
 export class MetadataValidationIssues {
-  static METADATA_INVALID_SIZE(path: string, message: string) {
-    const type = "METADATA_INVALID_SIZE";
+  /**
+   * Indicates an invalid byte length in binary metadata.
+   *
+   * This is used for the case that a buffer view of a property table
+   * has a size that does not match the expected size for the data
+   * that it should contain.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param message The message of the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static METADATA_INVALID_LENGTH(path: string, message: string) {
+    const type = "METADATA_INVALID_LENGTH";
     const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that the alignment requirements for binary metadata
+   * have not been met.
+   *
+   * This is used when the byte offset of a buffer view is not
+   * divisible by the size of the component type.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param message The message of the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static METADATA_INVALID_ALIGNMENT(path: string, message: string) {
     const type = "METADATA_INVALID_ALIGNMENT";
     const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that the 'arrayOffsets' or 'stringOffsets' in
+   * a binary property table property are invalid.
+   *
+   * This usually means that the offsets are not in ascending order.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param message The message of the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static METADATA_INVALID_OFFSETS(path: string, message: string) {
     const type = "METADATA_INVALID_OFFSETS";
     const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that a value that was found in binary metadata is
+   * not in the valid range.
+   *
+   * This means that the value is smaller than the minimum or
+   * larger than the maximum, for the minimum/maximum either
+   * being defined in the 'class property' or in the 'property
+   * table property'.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param message The message of the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static METADATA_VALUE_NOT_IN_RANGE(path: string, message: string) {
     const type = "METADATA_VALUE_NOT_IN_RANGE";
     const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that a value that was found in binary metadata does
+   * not match an expected value.
+   *
+   * This may be used, for example, when the minimum/maximum value
+   * that is computed from the values in a property table does not
+   * match the minimum/maximum that was defined for that
+   * property table property.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param message The message of the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static METADATA_VALUE_MISMATCH(path: string, message: string) {
     const type = "METADATA_VALUE_MISMATCH";
     const severity = ValidationIssueSeverity.ERROR;
@@ -37,6 +99,15 @@ export class MetadataValidationIssues {
     return issue;
   }
 
+  /**
+   * Indicates that a value of a property that was marked as
+   * 'required' in the schema was not defined for a metadata
+   * entity.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyName The name of the property
+   * @returns The `ValidationIssue`
+   */
   static METADATA_VALUE_REQUIRED_BUT_MISSING(
     path: string,
     propertyName: string
@@ -49,6 +120,18 @@ export class MetadataValidationIssues {
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that a class property in the metadata schema had
+   * a 'semantic' that was not known.
+   *
+   * TODO This is currently a WARNING, but will become an INFO soon!
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyName The name of the property
+   * @param semantic The semantic that was assigned to the property
+   * @returns The `ValidationIssue`
+   */
   static METADATA_SEMANTIC_UNKNOWN(
     path: string,
     propertyName: string,
@@ -60,9 +143,424 @@ export class MetadataValidationIssues {
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that a property had a semantic that was not valid for this
+   * property.
+   *
+   * This means that the metadata schema defined a class property with a
+   * certain 'semantic'. The 'semantic' was a known semantic, meaning
+   * that it was associated with expectations about the property type
+   * (e.g. that it should be a 'SCALAR' 'FLOAT32' value), and the
+   * property definition did not match the structure that was expected
+   * according to the semantic.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param message The message of the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static METADATA_SEMANTIC_INVALID(path: string, message: string) {
     const type = "METADATA_SEMANTIC_INVALID";
     const severity = ValidationIssueSeverity.ERROR;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a class property defined a 'componentType', even
+   * though the 'type' did not indicate a numeric type.
+   *
+   * The 'componentType' may only be defined for 'SCALAR', 'VECn',
+   * and 'MATn' types.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param componentType The component type
+   * @param theType The type
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_COMPONENT_TYPE_FOR_NON_NUMERIC_TYPE(
+    path: string,
+    componentType: string,
+    theType: string
+  ) {
+    const type = "CLASS_PROPERTY_COMPONENT_TYPE_FOR_NON_NUMERIC_TYPE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The 'componentType' was defined to be '${componentType}', but ` +
+      `must be undefined for a property with type '${theType}'`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a class property did not define a 'componentType',
+   * even though the 'type' did indicate a numeric type.
+   *
+   * The 'componentType' must be defined for 'SCALAR', 'VECn',
+   * and 'MATn' types.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param theType The type
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_COMPONENT_TYPE_MISSING(path: string, theType: string) {
+    const type = "CLASS_PROPERTY_COMPONENT_TYPE_MISSING";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The 'componentType' must be defined for a ` +
+      `property with type '${theType}'`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a class property defined an 'enumType', even though
+   * its 'type' was not 'ENUM'.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param enumType The enumType
+   * @param theType The type
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_ENUMTYPE_WITH_NON_ENUM_TYPE(
+    path: string,
+    enumType: string,
+    theType: string
+  ) {
+    const type = "CLASS_PROPERTY_ENUMTYPE_WITH_NON_ENUM_TYPE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The 'enumType' was defined to be '${enumType}', but ` +
+      `must be undefined for a property with type '${theType}'`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a class property did not define an 'enumType',
+   * even though its 'type' was 'ENUM'.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_ENUM_TYPE_WITHOUT_ENUMTYPE(path: string) {
+    const type = "CLASS_PROPERTY_ENUM_TYPE_WITHOUT_ENUMTYPE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message = `The property has the type 'ENUM', but no 'enumType' was defined`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a class property defined an 'enumType' which was
+   * not found in the schema definition.
+   *
+   * The 'enumType' must be the name of one of the enums that are
+   * defined in the 'schema.enums' dictionary.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param enumType The enumType
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_ENUMTYPE_NOT_FOUND(path: string, enumType: string) {
+    const type = "CLASS_PROPERTY_ENUMTYPE_NOT_FOUND";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The property refers to the 'enumType' to be '${enumType}', ` +
+      `but the schema does not define this 'enumType'`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a string that was given as an enum value was
+   * not found in the enum definition.
+   *
+   * The valid names for enum values for a class property are defined
+   * as the 'schema.enums[classProperty.enumType].values[i].name' values.
+   *
+   * This issue indicates that a string that was supposed to represent
+   * an enum value (e.g. when it was given in a JSON-based metadata
+   * entity, or as a 'noData' value of the property) did not appear in
+   * this list of valid names.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param name The name of the field or property that contained
+   * the invalid enum value name (for example, 'noData')
+   * @param propertyName The property name
+   * @param enumType The enumType
+   * @param enumValueName The invalid enum value name
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_ENUM_VALUE_NAME_NOT_FOUND(
+    path: string,
+    name: string,
+    propertyName: string,
+    enumType: string | undefined,
+    enumValueName: string
+  ) {
+    const type = "CLASS_PROPERTY_ENUM_VALUE_NAME_NOT_FOUND";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The value '${name}' of property '${propertyName}' refers to a value ` +
+      `with the name '${enumValueName}' of the enum '${enumType}', but this ` +
+      `enum does not define a value with this name`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that the 'count' property of a class property was
+   * defined, even though it was not defined to be an 'array'.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyName The property name
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_COUNT_FOR_NON_ARRAY(
+    path: string,
+    propertyName: string
+  ) {
+    const type = "CLASS_PROPERTY_COUNT_FOR_NON_ARRAY";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The property '${propertyName}' defines a 'count', but ` +
+      `the property is not an array`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that the 'normalized' property of a class property was
+   * truthy, but its 'type' does not allow normalization.
+   *
+   * Normalization may only be applied when the 'type' is 'SCALAR',
+   * 'VECn' or MATn'.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyName The property name
+   * @param propertyType The property type
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_NORMALIZED_FOR_NON_NORMALIZABLE_TYPE(
+    path: string,
+    propertyName: string,
+    propertyType: string
+  ) {
+    const type = "CLASS_PROPERTY_NORMALIZED_FOR_NON_NORMALIZABLE_TYPE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The property '${propertyName}' is defined to be 'normalized', ` +
+      `but the type '${propertyType}' can not be normalized`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that the 'normalized' property of a class property was
+   * truthy, but its 'componentType' does not allow normalization.
+   *
+   * Normalization may only be applied when the 'componentType' is
+   * an integer type.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyName The property name
+   * @param componentType The component type
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_NORMALIZED_FOR_NON_INTEGER_COMPONENT_TYPE(
+    path: string,
+    propertyName: string,
+    componentType: string
+  ) {
+    const type = "CLASS_PROPERTY_NORMALIZED_FOR_NON_NORMALIZABLE_TYPE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The property '${propertyName}' is defined to be 'normalized', ` +
+      `but the component type '${componentType}' is not an integer type`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that the 'offset' or 'scale' property of a class property
+   * or property table property was defined, but its type is not effectively
+   * a floating point type.
+   *
+   * A type is 'effectively floating point' when
+   * - The 'type' is 'SCALAR', 'VECn', or 'MATn'
+   * - AND:
+   * -  The 'componentType' is 'FLOATn'
+   * -  OR the 'componentType' is an integer type, and 'normalized'
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyName The property name
+   * @param offsetOrScale The property ('offset' or 'scale')
+   * @param propertyType The property type
+   * @param componentType The component type
+   * @param normalized The value of the 'normalized' property
+   * @returns The `ValidationIssue`
+   */
+  static METADATA_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE(
+    path: string,
+    propertyName: string,
+    offsetOrScale: string,
+    propertyType: string,
+    componentType: string | undefined,
+    normalized: boolean | undefined
+  ) {
+    const type = "METADATA_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The property '${propertyName}' is defines '${offsetOrScale}', ` +
+      `which is only applicable to properties with types 'SCALAR', ` +
+      `'VEC2', 'VEC3', 'VEC4', 'MAT2', 'MAT3', or 'MAT4' when they have ` +
+      `component types 'FLOAT32' or 'FLOAT64', or when they are normalized ` +
+      `and have component types 'INT8', 'UINT8', 'INT16', 'UINT16', 'INT32', ` +
+      `'UINT32', 'INT64', or 'UINT64', but the property has type ` +
+      `'${propertyType}' with component type '${componentType}' and ` +
+      `'normalized' is '${normalized}`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that the 'min' or 'max' property of a class property
+   * or property table property was defined, but its type is not a
+   * numeric type
+   *
+   * A type is numeric when the 'type' is 'SCALAR', 'VECn', or 'MATn'.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyName The property name
+   * @param minOrMax The property ('min' or 'max')
+   * @param propertyType The property type
+   * @returns The `ValidationIssue`
+   */
+  static METADATA_MIN_MAX_FOR_NON_NUMERIC_TYPE(
+    path: string,
+    propertyName: string,
+    minOrMax: string,
+    propertyType: string
+  ) {
+    const type = "METADATA_MIN_MAX_FOR_NON_NUMERIC_TYPE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The property '${propertyName}' is defines '${minOrMax}', ` +
+      `which is only applicable to properties with types 'SCALAR', ` +
+      `'VEC2', 'VEC3', 'VEC4', 'MAT2', 'MAT3', or 'MAT4', but the ` +
+      `property has type '${propertyType}'`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates an inconsistency in a class property definition.
+   *
+   * This indicates that
+   * - a 'noData' value was defined for a 'required' property
+   * - a 'noData' value was defined for a 'BOOLEAN' property
+   * - a 'default' value was defined for a 'required' property
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param message The message of the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTY_INCONSISTENT(path: string, message: string) {
+    const type = "CLASS_PROPERTY_INCONSISTENT";
+    const severity = ValidationIssueSeverity.ERROR;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a certain property was defined for a variable-length
+   * array property, but must be undefined for variable-length
+   * array properties.
+   *
+   * This refers to
+   * - the 'offset' and 'scale'
+   * - the 'min' and 'max'
+   * for both a 'class property' and a 'property table property'
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyName The property name
+   * @param invalidPropertyName The name of the property that should
+   * not be present ('min', 'max', 'offset', or 'scale')
+   * @returns The `ValidationIssue`
+   */
+  static METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY(
+    path: string,
+    propertyName: string,
+    invalidPropertyName: string
+  ) {
+    const type = "METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The property '${propertyName}' defines '${invalidPropertyName}', ` +
+      `which is not applicable to variable-length arrays`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a certain semantic was assigned to multiple properties.
+   *
+   * The class properties inside a schema may have a certain 'semantic'.
+   * But each semantic may only be applied to one property within each
+   * class.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param propertyNameA The name of the first property
+   * @param propertyNameB The name of the second property
+   * @param semantic The semantic that was assigned to both properties
+   * @returns The `ValidationIssue`
+   */
+  static CLASS_PROPERTIES_DUPLICATE_SEMANTIC(
+    path: string,
+    propertyNameA: string,
+    propertyNameB: string,
+    semantic: string
+  ) {
+    const type = "CLASS_PROPERTIES_DUPLICATE_SEMANTIC";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The semantic '${semantic}' was assigned to property ` +
+      `'${propertyNameA}' and property '${propertyNameB}'`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a certain name was used for multiple enum values.
+   *
+   * The 'enums[e].values[i].name' values must be unique for all 'i'.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param name The name that appeared more than once
+   * @returns The `ValidationIssue`
+   */
+  static ENUM_VALUE_DUPLICATE_NAME(path: string, name: string) {
+    const type = "ENUM_VALUE_DUPLICATE_NAME";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message = `There enum value name '${name}' is not unique`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a certain value was used for multiple enum values.
+   *
+   * The 'enums[e].values[i].value' values must be unique for all 'i'.
+   *
+   * @param path The path for the `ValidationIssue`
+   * @param value The value that appeared more than once
+   * @returns The `ValidationIssue`
+   */
+  static ENUM_VALUE_DUPLICATE_VALUE(path: string, value: number) {
+    const type = "ENUM_VALUE_DUPLICATE_VALUE";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message = `There enum value '${value}' is not unique`;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }

--- a/src/issues/SemanticValidationIssues.ts
+++ b/src/issues/SemanticValidationIssues.ts
@@ -2,9 +2,21 @@ import { ValidationIssue } from "../validation/ValidationIssue";
 import { ValidationIssueSeverity } from "../validation/ValidationIssueSeverity";
 import { ValidationIssueUtils } from "./ValidationIssueUtils";
 
-// TODO Each of these issues should be documented,
-// even more extensively than the basic ones!
+/**
+ * Methods to create `ValidationIssue` instances that describe
+ * issues related to the semantical validity of tilesets.
+ */
 export class SemanticValidationIssues {
+  /**
+   * Indicates that the 'version' string of a tileset asset
+   * had an unknown value.
+   *
+   * (The known values are defined by the 'AssetValidator' class)
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static ASSET_VERSION_UNKNOWN(path: string, message: string) {
     const type = "ASSET_VERSION_UNKNOWN";
     const severity = ValidationIssueSeverity.WARNING;
@@ -12,6 +24,18 @@ export class SemanticValidationIssues {
     return issue;
   }
 
+  /**
+   * Indicates that the 'refine' value of a tile was valid, but
+   * had an unexpected case.
+   *
+   * This only a warning, intended for legacy tilesets, where a
+   * value like 'Replace' was still valid. Current tilesets should
+   * always use uppercase values like 'REPLACE'.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static TILE_REFINE_WRONG_CASE(path: string, message: string) {
     const type = "TILE_REFINE_WRONG_CASE";
     const severity = ValidationIssueSeverity.WARNING;
@@ -19,6 +43,23 @@ export class SemanticValidationIssues {
     return issue;
   }
 
+  /**
+   * Indicates that the root tile of an implicit tileset was invalid.
+   *
+   * This is caused by the root tile of an implicit tileset defining
+   * one of the properties that are disallowed for implicit roots:
+   * - tile.children
+   * - tile.metadata
+   * - tile.content.boundingVolume
+   *
+   * It may also indicate that the required subtree information
+   * could not be created (for example, when the subtree data
+   * could not be read)
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static TILE_IMPLICIT_ROOT_INVALID(path: string, message: string) {
     const type = "TILE_IMPLICIT_ROOT_INVALID";
     const severity = ValidationIssueSeverity.ERROR;
@@ -26,13 +67,51 @@ export class SemanticValidationIssues {
     return issue;
   }
 
-  static BOUNDING_VOLUME_INCONSISTENT(path: string, message: string) {
-    const type = "BOUNDING_VOLUME_INCONSISTENT";
+  /**
+   * Indicates that a single bounding volume was invalid.
+   *
+   * This refers to certain constraints that are applied to
+   * specific bounding volume types. For example, that the
+   * radius of a bounding sphere may not be negative, or
+   * that the borders of a bounding regions are within
+   * valid ranges.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static BOUNDING_VOLUME_INVALID(path: string, message: string) {
+    const type = "BOUNDING_VOLUME_INVALID";
     const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
 
+  /**
+   * Indicates that a bounding volume structure was inconsistent.
+   *
+   * For now, this only means that a content bounding volume was
+   * not fully contained in the tile bounding volume.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static BOUNDING_VOLUMES_INCONSISTENT(path: string, message: string) {
+    const type = "BOUNDING_VOLUMES_INCONSISTENT";
+    const severity = ValidationIssueSeverity.ERROR;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that the minimum value of a 'tileset.properties'
+   * element was larger than the maximum.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static PROPERTIES_MINIMUM_LARGER_THAN_MAXIMUM(path: string, message: string) {
     const type = "PROPERTIES_MINIMUM_LARGER_THAN_MAXIMUM";
     const severity = ValidationIssueSeverity.ERROR;
@@ -40,211 +119,33 @@ export class SemanticValidationIssues {
     return issue;
   }
 
-  static TILE_GEOMETRIC_ERROR_INCONSISTENT(path: string, message: string) {
-    const type = "TILE_GEOMETRIC_ERROR_INCONSISTENT";
+  /**
+   * Indicates that the geometric error of a tile was larger than
+   * the geometric error of its parent.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static TILE_GEOMETRIC_ERRORS_INCONSISTENT(path: string, message: string) {
+    const type = "TILE_GEOMETRIC_ERRORS_INCONSISTENT";
     const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
 
-  static CLASS_PROPERTY_COMPONENT_TYPE_WITH_INVALID_TYPE(
-    path: string,
-    componentType: string,
-    theType: string
-  ) {
-    const type = "CLASS_PROPERTY_COMPONENT_TYPE_WITH_INVALID_TYPE";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The 'componentType' was defined to be '${componentType}', but ` +
-      `must be undefined for a property with type '${theType}'`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_COMPONENT_TYPE_MISSING(path: string, theType: string) {
-    const type = "CLASS_PROPERTY_COMPONENT_TYPE_MISSING";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The 'componentType' must be defined for a ` +
-      `property with type '${theType}'`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_ENUMTYPE_WITH_NON_ENUM_TYPE(
-    path: string,
-    enumType: string,
-    theType: string
-  ) {
-    const type = "CLASS_PROPERTY_ENUMTYPE_WITH_NON_ENUM_TYPE";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The 'enumType' was defined to be '${enumType}', but ` +
-      `must be undefined for a property with type '${theType}'`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_ENUM_TYPE_WITHOUT_ENUMTYPE(path: string) {
-    const type = "CLASS_PROPERTY_ENUM_TYPE_WITHOUT_ENUMTYPE";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message = `The property has the type 'ENUM', but no 'enumType' was defined`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_ENUMTYPE_NOT_FOUND(
-    path: string,
-    propertyName: string,
-    enumType: string
-  ) {
-    const type = "CLASS_PROPERTY_ENUMTYPE_NOT_FOUND";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The property '${propertyName}' refers to the 'enumType' ` +
-      `'${enumType}', but the schema does not define this 'enumType'`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_VALUE_ENUM_VALUE_NOT_FOUND(
-    path: string,
-    name: string,
-    propertyName: string,
-    enumType: string | undefined,
-    enumValueName: string
-  ) {
-    const type = "CLASS_PROPERTY_ENUM_VALUE_NOT_FOUND";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The value '${name}' of property '${propertyName}' refers to a value ` +
-      `with the name '${enumValueName}' of the enum '${enumType}', but this ` +
-      `enum does not define a value with this name`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_COUNT_FOR_NON_ARRAY(
-    path: string,
-    propertyName: string
-  ) {
-    const type = "CLASS_PROPERTY_COUNT_FOR_NON_ARRAY";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The property '${propertyName}' defines a 'count', but ` +
-      `the property is not an array`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_NORMALIZED_FOR_NON_NORMALIZABLE_TYPE(
-    path: string,
-    propertyName: string,
-    propertyType: string
-  ) {
-    const type = "CLASS_PROPERTY_NORMALIZED_FOR_NON_NORMALIZABLE_TYPE";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The property '${propertyName}' is defined to be 'normalized', ` +
-      `but the type '${propertyType}' can not be normalized`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_NORMALIZED_FOR_NON_INTEGER_COMPONENT_TYPE(
-    path: string,
-    propertyName: string,
-    componentType: string
-  ) {
-    const type = "CLASS_PROPERTY_NORMALIZED_FOR_NON_NORMALIZABLE_TYPE";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The property '${propertyName}' is defined to be 'normalized', ` +
-      `but the component type '${componentType}' is not an integer type`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE(
-    path: string,
-    propertyName: string,
-    offsetOrScale: string,
-    propertyType: string,
-    componentType: string | undefined,
-    normalized: boolean | undefined
-  ) {
-    const type = "CLASS_PROPERTY_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The property '${propertyName}' is defines '${offsetOrScale}', ` +
-      `which is only applicable to properties with types 'SCALAR', ` +
-      `'VEC2', 'VEC3', 'VEC4', 'MAT2', 'MAT3', or 'MAT4' when they have ` +
-      `component types 'FLOAT32' or 'FLOAT64', or when they are normalized ` +
-      `and have component types 'INT8', 'UINT8', 'INT16', 'UINT16', 'INT32', ` +
-      `'UINT32', 'INT64', or 'UINT64', but the property has type ` +
-      `'${propertyType}' with component type '${componentType}' and ` +
-      `'normalized' is '${normalized}`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTY_MIN_MAX_FOR_NON_NUMERIC_TYPE(
-    path: string,
-    propertyName: string,
-    minOrMax: string,
-    propertyType: string
-  ) {
-    const type = "CLASS_PROPERTY_MIN_MAX_FOR_NON_NUMERIC_TYPE";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The property '${propertyName}' is defines '${minOrMax}', ` +
-      `which is only applicable to properties with types 'SCALAR', ` +
-      `'VEC2', 'VEC3', 'VEC4', 'MAT2', 'MAT3', or 'MAT4', but the ` +
-      `property has type '${propertyType}'`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  // TODO Some of the highly specific issues above could be
-  // summarized in this one, with helpful messages...
-  static CLASS_PROPERTY_TYPE_ERROR(path: string, message: string) {
-    const type = "CLASS_PROPERTY_TYPE_ERROR";
-    const severity = ValidationIssueSeverity.ERROR;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static CLASS_PROPERTIES_DUPLICATE_SEMANTIC(
-    path: string,
-    propertyNameA: string,
-    propertyNameB: string,
-    semantic: string
-  ) {
-    const type = "CLASS_PROPERTIES_DUPLICATE_SEMANTIC";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message =
-      `The semantic '${semantic}' was assigned to property ` +
-      `'${propertyNameA}' and property '${propertyNameB}'`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static ENUM_VALUE_DUPLICATE_NAME(path: string, name: string) {
-    const type = "ENUM_VALUE_DUPLICATE_NAME";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message = `There enum value name '${name}' is not unique`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
-  static ENUM_VALUE_DUPLICATE_VALUE(path: string, value: number) {
-    const type = "ENUM_VALUE_DUPLICATE_VALUE";
-    const severity = ValidationIssueSeverity.ERROR;
-    const message = `There enum value '${value}' is not unique`;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
+  /**
+   * Indicates that a template URI contained an invalid variable name.
+   *
+   * The template URIs that are used for contents or subtree files
+   * in implicit tiling may contain variables like '{level}', and
+   * this issue indicates that there was an invalid variable name.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param variableName The variable name
+   * @param validVariableNames The valid variable names
+   * @returns The `ValidationIssue`
+   */
   static TEMPLATE_URI_INVALID_VARIABLE_NAME(
     path: string,
     variableName: string,
@@ -259,6 +160,19 @@ export class SemanticValidationIssues {
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that a template URI did not contain an expected variable name.
+   *
+   * The template URIs that are used for contents or subtree files
+   * in implicit tiling are expected to contain certain variable
+   * names. This issue is only a 'WARNING' for the case that an
+   * expected name was not used.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param missingVVariableNames The missing variable names
+   * @returns The `ValidationIssue`
+   */
   static TEMPLATE_URI_MISSING_VARIABLE_NAME(
     path: string,
     missingVVariableNames: string[]
@@ -274,13 +188,21 @@ export class SemanticValidationIssues {
     return issue;
   }
 
-  static TRAVERSAL_ERROR(path: string, message: string) {
-    const type = "TRAVERSAL_ERROR";
-    const severity = ValidationIssueSeverity.ERROR;
-    const issue = new ValidationIssue(type, path, message, severity);
-    return issue;
-  }
-
+  /**
+   * Indicates an error in an implicit tileset structure.
+   *
+   * This is a generic error indicating that the internal structures
+   * for traversing the implicit tileset could not be created.
+   * Clients should rarely see this message, because errors that
+   * prevent the traversal should be caught earlier (and prevent
+   * the traversal attempts). But if it happens, the 'message'
+   * should contain further information about the reason for
+   * the error.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static IMPLICIT_TILING_ERROR(path: string, message: string) {
     const type = "IMPLICIT_TILING_ERROR";
     const severity = ValidationIssueSeverity.ERROR;
@@ -288,6 +210,17 @@ export class SemanticValidationIssues {
     return issue;
   }
 
+  /**
+   * Indicates an inconsistency of buffers and buffer views.
+   *
+   * This mainly refers to the 'buffers' and 'bufferViews' of
+   * an implicit subtree. It may, for example, inciate that a
+   * buffer view does not fit into the buffer that it refers to.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static BUFFERS_INCONSISTENT(path: string, message: string) {
     const type = "BUFFERS_INCONSISTENT";
     const severity = ValidationIssueSeverity.ERROR;
@@ -295,6 +228,22 @@ export class SemanticValidationIssues {
     return issue;
   }
 
+  /**
+   * Indicates an inconsistency in availability information.
+   *
+   * The availability information for tiles, content, and child
+   * subtrees that is stored as part of an implicit tileset has
+   * to obey certain constraints. For example:
+   * - When a content is available, then the tile must be available
+   * - When a tile is available, then the parent tile must be available
+   *
+   * More specific information about the inconsistency is given
+   * in the error message.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static SUBTREE_AVAILABILITY_INCONSISTENT(path: string, message: string) {
     const type = "SUBTREE_AVAILABILITY_INCONSISTENT";
     const severity = ValidationIssueSeverity.ERROR;
@@ -302,6 +251,17 @@ export class SemanticValidationIssues {
     return issue;
   }
 
+  /**
+   * Indicates that a tile transform was invalid.
+   *
+   * The exact constraints for being 'valid' are not specified.
+   * For now, this indicates that the transform matrix was
+   * the zero-matrix.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param message The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
   static TRANSFORM_INVALID(path: string, message: string) {
     const type = "TRANSFORM_INVALID";
     const severity = ValidationIssueSeverity.ERROR;
@@ -309,6 +269,15 @@ export class SemanticValidationIssues {
     return issue;
   }
 
+  /**
+   * Indicates that a certain extension was listed in the
+   * 'extensionsRequired', but not in the 'extensionsUsed'
+   * of a tileset.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param extensionName The extension name
+   * @returns The `ValidationIssue`
+   */
   static EXTENSION_REQUIRED_BUT_NOT_USED(path: string, extensionName: string) {
     const type = "EXTENSION_REQUIRED_BUT_NOT_USED";
     const severity = ValidationIssueSeverity.ERROR;
@@ -318,6 +287,19 @@ export class SemanticValidationIssues {
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that a certain extension was found, but was not
+   * listed in the 'extensionsUsed' of a tileset.
+   *
+   * An extension is 'found' when it is encountered in any
+   * 'someRootProperty.extensons' dictionary during the
+   * traversal,
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param extensionName The extension name
+   * @returns The `ValidationIssue`
+   */
   static EXTENSION_FOUND_BUT_NOT_USED(path: string, extensionName: string) {
     const type = "EXTENSION_FOUND_BUT_NOT_USED";
     const severity = ValidationIssueSeverity.ERROR;
@@ -327,6 +309,23 @@ export class SemanticValidationIssues {
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that a certain extension was listed in the
+   * 'extensionsUsed' of a tileset, but not found during
+   * the traversal.
+   *
+   * An extension is 'found' when it is encountered in any
+   * 'someRootProperty.extensons' dictionary during the
+   * traversal.
+   *
+   * NOTE: The exact mechanism for an extension being "used" may have to be
+   * reviewed. See https://github.com/CesiumGS/3d-tiles-validator/issues/231
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param extensionName The extension name
+   * @returns The `ValidationIssue`
+   */
   static EXTENSION_USED_BUT_NOT_FOUND(path: string, extensionName: string) {
     const type = "EXTENSION_USED_BUT_NOT_FOUND";
     const severity = ValidationIssueSeverity.WARNING;
@@ -336,6 +335,16 @@ export class SemanticValidationIssues {
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }
+
+  /**
+   * Indicates that a certain extension was found during
+   * the traversal, but is not known or handled by the
+   * validator in any way.
+   *
+   * @param path The JSON path for the `ValidationIssue`
+   * @param extensionName The extension name
+   * @returns The `ValidationIssue`
+   */
   static EXTENSION_NOT_SUPPORTED(path: string, extensionName: string) {
     const type = "EXTENSION_NOT_SUPPORTED";
     const severity = ValidationIssueSeverity.WARNING;

--- a/src/validation/BoundingVolumeValidator.ts
+++ b/src/validation/BoundingVolumeValidator.ts
@@ -241,7 +241,7 @@ export class BoundingVolumeValidator {
       const message =
         `The 'radius' entry of the bounding sphere ` +
         `may not be negative, but is ${radius}`;
-      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INVALID(
         path + "/3",
         message
       );
@@ -295,7 +295,7 @@ export class BoundingVolumeValidator {
       const message =
         `The 'west' entry of the bounding region ` +
         `must be in [-PI,PI], but is ${westRad}`;
-      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INVALID(
         path + "/0",
         message
       );
@@ -306,7 +306,7 @@ export class BoundingVolumeValidator {
       const message =
         `The 'south' entry of the bounding region ` +
         `must be in [-PI/2,PI/2], but is ${southRad}`;
-      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INVALID(
         path + "/1",
         message
       );
@@ -317,7 +317,7 @@ export class BoundingVolumeValidator {
       const message =
         `The 'east' entry of the bounding region ` +
         `must be in [-PI,PI], but is ${eastRad}`;
-      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INVALID(
         path + "/2",
         message
       );
@@ -328,7 +328,7 @@ export class BoundingVolumeValidator {
       const message =
         `The 'north' entry of the bounding region ` +
         `must be in [-PI/2,PI/2], but is ${northRad}`;
-      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INVALID(
         path + "/3",
         message
       );
@@ -340,7 +340,7 @@ export class BoundingVolumeValidator {
         `The 'south' entry of the bounding region ` +
         `may not be larger than the 'north' entry, but the south ` +
         `is ${southRad} and the north is ${northRad}`;
-      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INVALID(
         path,
         message
       );
@@ -352,7 +352,7 @@ export class BoundingVolumeValidator {
         `The minimum height of the bounding region ` +
         `may not be larger than the maximum height, but the minimum height ` +
         `is ${minimumHeight} and the maximum height is ${maximumHeight}`;
-      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INVALID(
         path,
         message
       );

--- a/src/validation/TileContentValidator.ts
+++ b/src/validation/TileContentValidator.ts
@@ -107,7 +107,7 @@ export class TileContentValidator {
       const message =
         `The content bounding volume is not contained ` +
         `in the tile bounding volume: ${errorMessage}`;
-      const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+      const issue = SemanticValidationIssues.BOUNDING_VOLUMES_INCONSISTENT(
         contentBoundingVolumePath,
         message
       );

--- a/src/validation/TilesetTraversingValidator.ts
+++ b/src/validation/TilesetTraversingValidator.ts
@@ -379,7 +379,7 @@ export class TilesetTraversingValidator {
         `Tile ${path} has a geometricError of ${tileGeometricError}, ` +
         `which is larger than the parent geometricError ` +
         `of ${parentGeometricError}`;
-      const issue = SemanticValidationIssues.TILE_GEOMETRIC_ERROR_INCONSISTENT(
+      const issue = SemanticValidationIssues.TILE_GEOMETRIC_ERRORS_INCONSISTENT(
         path,
         message
       );

--- a/src/validation/extensions/BoundingVolumeS2Validator.ts
+++ b/src/validation/extensions/BoundingVolumeS2Validator.ts
@@ -207,7 +207,7 @@ export class BoundingVolumeS2Validator implements Validator<any> {
           `The minimumHeight may not be larger than the ` +
           `maximumHeight, but the minimumHeight is ${minimumHeight} ` +
           `and the maximum height is ${maximumHeight}`;
-        const issue = SemanticValidationIssues.BOUNDING_VOLUME_INCONSISTENT(
+        const issue = SemanticValidationIssues.BOUNDING_VOLUME_INVALID(
           path,
           message
         );

--- a/src/validation/metadata/BinaryPropertyTableValidator.ts
+++ b/src/validation/metadata/BinaryPropertyTableValidator.ts
@@ -621,7 +621,7 @@ export class BinaryPropertyTableValidator {
         `have a byteLength of ${numValues}*${componentTypeByteSize} = ` +
         `${expectedByteLength}. But the buffer view with index ` +
         `${bufferViewIndex} has a byteLength of ${actualByteLength}`;
-      const issue = MetadataValidationIssues.METADATA_INVALID_SIZE(
+      const issue = MetadataValidationIssues.METADATA_INVALID_LENGTH(
         path,
         message
       );
@@ -677,7 +677,7 @@ export class BinaryPropertyTableValidator {
         numValues,
         expectedByteLength
       );
-      const issue = MetadataValidationIssues.METADATA_INVALID_SIZE(
+      const issue = MetadataValidationIssues.METADATA_INVALID_LENGTH(
         path,
         message
       );

--- a/src/validation/metadata/ClassPropertySemanticsValidator.ts
+++ b/src/validation/metadata/ClassPropertySemanticsValidator.ts
@@ -5,7 +5,6 @@ import { ValidationContext } from "./../ValidationContext";
 
 import { ClassProperty } from "../../structure/Metadata/ClassProperty";
 
-import { SemanticValidationIssues } from "../../issues/SemanticValidationIssues";
 import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
 
 /**
@@ -45,7 +44,7 @@ export class ClassPropertySemanticsValidator {
           const otherPropertyName = semanticsToPropertyNames[semantic!];
           if (defined(otherPropertyName)) {
             const issue =
-              SemanticValidationIssues.CLASS_PROPERTIES_DUPLICATE_SEMANTIC(
+              MetadataValidationIssues.CLASS_PROPERTIES_DUPLICATE_SEMANTIC(
                 metadataClassPath,
                 propertyName,
                 otherPropertyName,

--- a/src/validation/metadata/ClassPropertyValidator.ts
+++ b/src/validation/metadata/ClassPropertyValidator.ts
@@ -13,8 +13,8 @@ import { ClassProperty } from "../../structure/Metadata/ClassProperty";
 import { MetadataTypes } from "../../metadata/MetadataTypes";
 import { MetadataComponentTypes } from "../../metadata/MetadataComponentTypes";
 
-import { SemanticValidationIssues } from "../../issues/SemanticValidationIssues";
 import { JsonValidationIssues } from "../../issues/JsonValidationIssues";
+import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
 
 /**
  * A class for validations related to `class.property` objects.
@@ -136,7 +136,7 @@ export class ClassPropertyValidator {
       // componentType MUST be defined
       if (isNumericType) {
         const issue =
-          SemanticValidationIssues.CLASS_PROPERTY_COMPONENT_TYPE_MISSING(
+          MetadataValidationIssues.CLASS_PROPERTY_COMPONENT_TYPE_MISSING(
             componentTypePath,
             type
           );
@@ -147,7 +147,7 @@ export class ClassPropertyValidator {
     if (!isNumericType && defined(componentType)) {
       // For non-numeric types the componentType MUST NOT be defined
       const issue =
-        SemanticValidationIssues.CLASS_PROPERTY_COMPONENT_TYPE_WITH_INVALID_TYPE(
+        MetadataValidationIssues.CLASS_PROPERTY_COMPONENT_TYPE_FOR_NON_NUMERIC_TYPE(
           componentTypePath,
           componentType!,
           type
@@ -188,7 +188,7 @@ export class ClassPropertyValidator {
     // When the type is "ENUM", then the enumType MUST be defined
     if (type === "ENUM" && !defined(enumType)) {
       const issue =
-        SemanticValidationIssues.CLASS_PROPERTY_ENUM_TYPE_WITHOUT_ENUMTYPE(
+        MetadataValidationIssues.CLASS_PROPERTY_ENUM_TYPE_WITHOUT_ENUMTYPE(
           propertyPath
         );
       context.addIssue(issue);
@@ -196,7 +196,7 @@ export class ClassPropertyValidator {
     } else if (type !== "ENUM" && defined(enumType)) {
       // When the type is not "ENUM", then the enumType MUST NOT be defined
       const issue =
-        SemanticValidationIssues.CLASS_PROPERTY_ENUMTYPE_WITH_NON_ENUM_TYPE(
+        MetadataValidationIssues.CLASS_PROPERTY_ENUMTYPE_WITH_NON_ENUM_TYPE(
           enumTypePath,
           enumType!,
           type
@@ -220,9 +220,8 @@ export class ClassPropertyValidator {
         const enums = defaultValue(schema.enums, {});
         if (!Object.keys(enums).includes(enumType!)) {
           const issue =
-            SemanticValidationIssues.CLASS_PROPERTY_ENUMTYPE_NOT_FOUND(
+            MetadataValidationIssues.CLASS_PROPERTY_ENUMTYPE_NOT_FOUND(
               propertyPath,
-              propertyName,
               enumType!
             );
           context.addIssue(issue);
@@ -265,7 +264,7 @@ export class ClassPropertyValidator {
       // When the count is defined, then the property MUST be an array
       if (!array) {
         const issue =
-          SemanticValidationIssues.CLASS_PROPERTY_COUNT_FOR_NON_ARRAY(
+          MetadataValidationIssues.CLASS_PROPERTY_COUNT_FOR_NON_ARRAY(
             propertyPath,
             propertyName
           );
@@ -295,7 +294,7 @@ export class ClassPropertyValidator {
         // of the numeric types (SCALAR, VECn, MATn)
         if (!MetadataTypes.isNumericType(type)) {
           const issue =
-            SemanticValidationIssues.CLASS_PROPERTY_NORMALIZED_FOR_NON_NORMALIZABLE_TYPE(
+            MetadataValidationIssues.CLASS_PROPERTY_NORMALIZED_FOR_NON_NORMALIZABLE_TYPE(
               propertyPath,
               propertyName,
               type
@@ -308,7 +307,7 @@ export class ClassPropertyValidator {
           // MUST be an integer type
           if (!MetadataComponentTypes.isIntegerComponentType(componentType!)) {
             const issue =
-              SemanticValidationIssues.CLASS_PROPERTY_NORMALIZED_FOR_NON_INTEGER_COMPONENT_TYPE(
+              MetadataValidationIssues.CLASS_PROPERTY_NORMALIZED_FOR_NON_INTEGER_COMPONENT_TYPE(
                 propertyPath,
                 propertyName,
                 componentType!
@@ -346,7 +345,7 @@ export class ClassPropertyValidator {
         const message =
           `The property '${propertyName}' defines a 'noData' ` +
           `value, but is 'required'`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
+        const issue = MetadataValidationIssues.CLASS_PROPERTY_INCONSISTENT(
           noDataPath,
           message
         );
@@ -357,7 +356,7 @@ export class ClassPropertyValidator {
         const message =
           `The property '${propertyName}' defines a 'noData' ` +
           `value, but has the type 'BOOLEAN'`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
+        const issue = MetadataValidationIssues.CLASS_PROPERTY_INCONSISTENT(
           noDataPath,
           message
         );
@@ -375,7 +374,7 @@ export class ClassPropertyValidator {
         const message =
           `The property '${propertyName}' defines a 'default' ` +
           `value, but is 'required'`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
+        const issue = MetadataValidationIssues.CLASS_PROPERTY_INCONSISTENT(
           defaultPath,
           message
         );

--- a/src/validation/metadata/ClassPropertyValueValidator.ts
+++ b/src/validation/metadata/ClassPropertyValueValidator.ts
@@ -1,11 +1,13 @@
+import { defined } from "../../base/defined";
+
 import { ValidationContext } from "../ValidationContext";
+
 import { ClassProperties } from "./ClassProperties";
 import { MetadataValueValidator } from "./MetadataValueValidator";
 
 import { ClassProperty } from "../../structure/Metadata/ClassProperty";
 
-import { SemanticValidationIssues } from "../../issues/SemanticValidationIssues";
-import { defined } from "../../base/defined";
+import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
 
 /**
  * A class for validations of metadata values against the definitions
@@ -22,7 +24,7 @@ export class ClassPropertyValueValidator {
    * for the given property.
    *
    * If the property does not have a numeric type, then a
-   * `CLASS_PROPERTY_MIN_MAX_FOR_NON_NUMERIC_TYPE` validation
+   * `METADATA_MIN_MAX_FOR_NON_NUMERIC_TYPE` validation
    * issue will be added to the given context.
    *
    * If the structure of the given value does not match the
@@ -53,7 +55,7 @@ export class ClassPropertyValueValidator {
     // When the max/min is given, the property MUST have a numeric type
     if (!ClassProperties.hasNumericType(property)) {
       const issue =
-        SemanticValidationIssues.CLASS_PROPERTY_MIN_MAX_FOR_NON_NUMERIC_TYPE(
+        MetadataValidationIssues.METADATA_MIN_MAX_FOR_NON_NUMERIC_TYPE(
           path,
           propertyName,
           maxOrMin,
@@ -65,13 +67,12 @@ export class ClassPropertyValueValidator {
       // The offset/scale property MUST NOT be given
       // for variable-length arrays
       if (property.array === true && !defined(property.count)) {
-        const message =
-          `The property '${propertyName}' defines '${maxOrMin}', ` +
-          `which is not applicable to variable-length arrays`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
-          path,
-          message
-        );
+        const issue =
+          MetadataValidationIssues.METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY(
+            path,
+            propertyName,
+            maxOrMin
+          );
         context.addIssue(issue);
         result = false;
       } else {
@@ -97,7 +98,7 @@ export class ClassPropertyValueValidator {
    * for the given property.
    *
    * If the property does not have a numeric type, then a
-   * `CLASS_PROPERTY_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE` validation
+   * `METADATA_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE` validation
    * issue will be added to the given context.
    *
    * If the structure of the given value does not match the
@@ -130,7 +131,7 @@ export class ClassPropertyValueValidator {
     // When the offset/scale is given, the property MUST have a 'floating point type'
     if (!ClassProperties.hasEffectivelyFloatingPointType(property)) {
       const issue =
-        SemanticValidationIssues.CLASS_PROPERTY_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE(
+        MetadataValidationIssues.METADATA_OFFSET_SCALE_FOR_NON_FLOATING_POINT_TYPE(
           path,
           propertyName,
           offsetOrScale,
@@ -144,13 +145,12 @@ export class ClassPropertyValueValidator {
       // The offset/scale property MUST NOT be given
       // for variable-length arrays
       if (property.array === true && !defined(property.count)) {
-        const message =
-          `The property '${propertyName}' defines '${offsetOrScale}', ` +
-          `which is not applicable to variable-length arrays`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
-          path,
-          message
-        );
+        const issue =
+          MetadataValidationIssues.METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY(
+            path,
+            propertyName,
+            offsetOrScale
+          );
         context.addIssue(issue);
         result = false;
       } else {

--- a/src/validation/metadata/MetadataEnumValidator.ts
+++ b/src/validation/metadata/MetadataEnumValidator.ts
@@ -11,7 +11,7 @@ import { MetadataComponentTypes } from "../../metadata/MetadataComponentTypes";
 import { MetadataEnum } from "../../structure/Metadata/MetadataEnum";
 import { EnumValue } from "../../structure/Metadata/EnumValue";
 
-import { SemanticValidationIssues } from "../../issues/SemanticValidationIssues";
+import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
 
 /**
  * A class for validations related to `MetadataEnum` objects.
@@ -252,7 +252,7 @@ export class MetadataEnumValidator {
       const value = array[i];
       const index = array.indexOf(value);
       if (index != i) {
-        const issue = SemanticValidationIssues.ENUM_VALUE_DUPLICATE_NAME(
+        const issue = MetadataValidationIssues.ENUM_VALUE_DUPLICATE_NAME(
           path,
           value
         );
@@ -283,7 +283,7 @@ export class MetadataEnumValidator {
       const value = array[i];
       const index = array.indexOf(value);
       if (index != i) {
-        const issue = SemanticValidationIssues.ENUM_VALUE_DUPLICATE_VALUE(
+        const issue = MetadataValidationIssues.ENUM_VALUE_DUPLICATE_VALUE(
           path,
           value
         );

--- a/src/validation/metadata/MetadataValueValidator.ts
+++ b/src/validation/metadata/MetadataValueValidator.ts
@@ -8,7 +8,7 @@ import { MetadataTypes } from "../../metadata/MetadataTypes";
 import { Schema } from "../../structure/Metadata/Schema";
 import { ClassProperty } from "../../structure/Metadata/ClassProperty";
 
-import { SemanticValidationIssues } from "../../issues/SemanticValidationIssues";
+import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
 
 /**
  * A class for validations of metadata values against the definitions
@@ -276,7 +276,7 @@ export class MetadataValueValidator {
     // values from the enum definition
     if (!enumValueNames.includes(enumValueName)) {
       const issue =
-        SemanticValidationIssues.CLASS_PROPERTY_VALUE_ENUM_VALUE_NOT_FOUND(
+        MetadataValidationIssues.CLASS_PROPERTY_ENUM_VALUE_NAME_NOT_FOUND(
           path,
           name,
           propertyName,

--- a/src/validation/metadata/PropertyTablePropertyValidator.ts
+++ b/src/validation/metadata/PropertyTablePropertyValidator.ts
@@ -11,7 +11,7 @@ import { ClassProperty } from "../../structure/Metadata/ClassProperty";
 import { MetadataComponentTypes } from "../../metadata/MetadataComponentTypes";
 
 import { StructureValidationIssues } from "../../issues/StructureValidationIssues";
-import { SemanticValidationIssues } from "../../issues/SemanticValidationIssues";
+import { MetadataValidationIssues } from "../../issues/MetadataValidationIssues";
 
 /**
  * A class for validations related to `propertyTable.property` objects.
@@ -194,13 +194,12 @@ export class PropertyTablePropertyValidator {
     if (defined(offset)) {
       // The 'offset' MUST not be given for variable-length arrays
       if (isVariableLengthArray) {
-        const message =
-          `The property '${propertyName}' defines 'offset', ` +
-          `which is not applicable to variable-length arrays`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
-          path,
-          message
-        );
+        const issue =
+          MetadataValidationIssues.METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY(
+            path,
+            propertyName,
+            "offset"
+          );
         context.addIssue(issue);
         result = false;
       } else {
@@ -224,13 +223,12 @@ export class PropertyTablePropertyValidator {
     if (defined(scale)) {
       // The 'scale' MUST not be given for variable-length arrays
       if (isVariableLengthArray) {
-        const message =
-          `The property '${propertyName}' defines 'scale', ` +
-          `which is not applicable to variable-length arrays`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
-          path,
-          message
-        );
+        const issue =
+          MetadataValidationIssues.METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY(
+            path,
+            propertyName,
+            "scale"
+          );
         context.addIssue(issue);
         result = false;
       } else {
@@ -254,13 +252,12 @@ export class PropertyTablePropertyValidator {
     if (defined(max)) {
       // The 'max' MUST not be given for variable-length arrays
       if (isVariableLengthArray) {
-        const message =
-          `The property '${propertyName}' defines 'max', ` +
-          `which is not applicable to variable-length arrays`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
-          path,
-          message
-        );
+        const issue =
+          MetadataValidationIssues.METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY(
+            path,
+            propertyName,
+            "max"
+          );
         context.addIssue(issue);
         result = false;
       } else {
@@ -284,13 +281,12 @@ export class PropertyTablePropertyValidator {
     if (defined(min)) {
       // The 'min' MUST not be given for variable-length arrays
       if (isVariableLengthArray) {
-        const message =
-          `The property '${propertyName}' defines 'min', ` +
-          `which is not applicable to variable-length arrays`;
-        const issue = SemanticValidationIssues.CLASS_PROPERTY_TYPE_ERROR(
-          path,
-          message
-        );
+        const issue =
+          MetadataValidationIssues.METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY(
+            path,
+            propertyName,
+            "min"
+          );
         context.addIssue(issue);
         result = false;
       } else {


### PR DESCRIPTION
This is the first step of addressing https://github.com/CesiumGS/3d-tiles-validator/issues/240 . The changes in this PR should **not** affect the overall functionality or features. They are only about moving/renaming of issues, and adding comments: 

- Moved some of the issues that are related to metadata validation from the `SemanticValidationIssues` class into the `MetadataValidationIssues` class
- Made some issues a bit more specific, or their names more precise. Examples:
  - `BOUNDING_VOLUME_INCONSISTENT` was used for things like 'negative bounding sphere radius' _and_ for 'content BV not in tile BV'. This is now split into `BOUNDING_VOLUME_INVALID` and `BOUNDING_VOLUMES_INCONSISTENT`. 
  - `CLASS_PROPERTY_COMPONENT_TYPE_WITH_INVALID_TYPE` is now `CLASS_PROPERTY_COMPONENT_TYPE_FOR_NON_NUMERIC_TYPE` (even though the message already contained the relevant information about what 'invalid' meant here...)
  - Some instances of `CLASS_PROPERTY_TYPE_ERROR` are now more specific, namely `METADATA_PROPERTY_INVALID_FOR_VARIABLE_LENGTH_ARRAY` (the min/max/scale/offset are not allowed for variable-length arrays)
- Added comments for the issues. They can always be extended or improved, but the current state should be a reasonable start.

