### PR TITLE
Fix for statistics class validation

### DIFF
--- a/specs/TilesetValidationSpec.ts
+++ b/specs/TilesetValidationSpec.ts
@@ -364,9 +364,17 @@ describe("Tileset validation", function () {
     expect(result.get(0).type).toEqual("NUMBER_OF_PROPERTIES_MISMATCH");
   });
 
-  it("detects issues in statisticsClassesPropertyNameInvalid", async function () {
+  it("detects issues in statisticsClassesPropertiesMinPropertiesMismatch", async function () {
     const result = await Validators.validateTilesetFile(
-      "specs/data/tilesets/statisticsClassesPropertyNameInvalid.json"
+      "specs/data/tilesets/statisticsClassesPropertiesMinPropertiesMismatch.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("NUMBER_OF_PROPERTIES_MISMATCH");
+  });
+
+  it("detects issues in statisticsClassesPropertiesPropertyNameInvalid", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/tilesets/statisticsClassesPropertiesPropertyNameInvalid.json"
     );
     expect(result.length).toEqual(1);
     expect(result.get(0).type).toEqual("IDENTIFIER_NOT_FOUND");

--- a/specs/data/tilesets/statisticsClassesPropertiesMinPropertiesMismatch.json
+++ b/specs/data/tilesets/statisticsClassesPropertiesMinPropertiesMismatch.json
@@ -1,6 +1,6 @@
 {
-  "asset": {
-    "version": "1.1"
+  "asset" : {
+    "version" : "1.1"
   },
   "schema": {
     "id": "EXAMPLE_ID",
@@ -15,20 +15,17 @@
       }
     }
   },
-  "geometricError": 2.0,
-  "root": {
-    "boundingVolume": {
-      "box": [0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5]
+  "geometricError" : 2.0,
+  "root" : {
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
     },
-    "geometricError": 1.0
+    "geometricError" : 1.0
   },
   "statistics": {
     "classes": {
       "exampleClass": {
-        "INVALID_PROPERTY_NAME": {
-          "min": 0.0,
-          "max": 10.0
-        }
+        "properties": {}
       }
     }
   }

--- a/specs/data/tilesets/statisticsClassesPropertiesPropertyNameInvalid.json
+++ b/specs/data/tilesets/statisticsClassesPropertiesPropertyNameInvalid.json
@@ -1,0 +1,37 @@
+{
+  "asset": {
+    "version": "1.1"
+  },
+  "schema": {
+    "id": "EXAMPLE_ID",
+    "classes": {
+      "exampleClass": {
+        "properties": {
+          "exampleProperty": {
+            "type": "SCALAR",
+            "componentType": "FLOAT32"
+          }
+        }
+      }
+    }
+  },
+  "geometricError": 2.0,
+  "root": {
+    "boundingVolume": {
+      "box": [0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5]
+    },
+    "geometricError": 1.0
+  },
+  "statistics": {
+    "classes": {
+      "exampleClass": {
+        "properties": {
+          "INVALID_PROPERTY_NAME": {
+            "min": 0.0,
+            "max": 10.0
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/validation/StatisticsClassValidator.ts
+++ b/src/validation/StatisticsClassValidator.ts
@@ -9,6 +9,7 @@ import { StatisticsClass } from "../structure/StatisticsClass";
 import { Schema } from "../structure/Metadata/Schema";
 
 import { StructureValidationIssues } from "../issues/StructureValidationIssues";
+import { defaultValue } from "cesium";
 
 /**
  * A class for validations related to `StatisticsClass` objects.
@@ -98,22 +99,45 @@ export class StatisticsClassValidator {
       // Each property name of the statistics class MUST be a
       // property name of the schema class
       const metadataClassPropertyNames = Object.keys(metadataClass.properties);
-      for (const statisticsClassPropetyName of Object.keys(statisticsClass)) {
-        if (!metadataClassPropertyNames.includes(statisticsClassPropetyName)) {
-          const message =
-            `Statistics class '${className}' contains a property name ` +
-            `'${statisticsClassPropetyName}', but the schema class does ` +
-            `not define this property`;
-          const issue = StructureValidationIssues.IDENTIFIER_NOT_FOUND(
-            classPath,
-            message
-          );
-          context.addIssue(issue);
-          result = false;
-        } else {
-          // TODO Validate the constraints for the statistics.class.property.
-          // This COULD include checks for (min>max). But first, it should
-          // check the types (e.g. that 'min' is only used for numeric types)
+
+      // The statistics class MUST have at least 1 property
+      const statisticsClassProperties = defaultValue(
+        statisticsClass.properties,
+        {}
+      );
+      if (
+        !BasicValidator.validateNumberOfProperties(
+          classPath,
+          "properties",
+          statisticsClassProperties,
+          1,
+          undefined,
+          context
+        )
+      ) {
+        result = false;
+      } else {
+        for (const statisticsClassPropetyName of Object.keys(
+          statisticsClassProperties
+        )) {
+          if (
+            !metadataClassPropertyNames.includes(statisticsClassPropetyName)
+          ) {
+            const message =
+              `Statistics class '${className}' contains a property name ` +
+              `'${statisticsClassPropetyName}', but the schema class does ` +
+              `not define this property`;
+            const issue = StructureValidationIssues.IDENTIFIER_NOT_FOUND(
+              classPath,
+              message
+            );
+            context.addIssue(issue);
+            result = false;
+          } else {
+            // TODO Validate the constraints for the statistics.class.property.
+            // This COULD include checks for (min>max). But first, it should
+            // check the types (e.g. that 'min' is only used for numeric types)
+          }
         }
       }
     }


### PR DESCRIPTION
The validation of the `statistics.class` properties did not properly take into account that the _actual_ properties are in the `properties` sub-object - so it assumed that the structure was
```JSONC
  "statistics": {
    "classes": {
      "exampleMetadataClass": {
          "intensity": {}
      }
    }
  }
```
instead of
```JSONC
  "statistics": {
    "classes": {
      "exampleMetadataClass": {
        "properties": { //---------------! 
          "intensity": {}
        }
      }
    }
  }
