### PR TITLE
Unzip package entries if they are zipped

### DIFF
--- a/src/validation/TilesetPackageValidator.ts
+++ b/src/validation/TilesetPackageValidator.ts
@@ -7,6 +7,7 @@ import { Validator } from "./Validator";
 import { ValidationContext } from "./ValidationContext";
 
 import { PackageResourceResolver } from "../io/PackageResourceResolver";
+import { UnzippingResourceResolver } from "../io/UnzippingResourceResolver";
 
 import { ContentValidationIssues } from "../issues/ContentValidationIssues";
 import { IoValidationIssues } from "../issues/IoValidationIssue";
@@ -184,10 +185,13 @@ export class TilesetPackageValidator implements Validator<string> {
     // Create the `PackageResourceResolver` from the package,
     // and obtain the data for the `tileset.json` file.
     // This has to be present according to the 3TZ specification.
-    const packageResourceResolver = new PackageResourceResolver(
+    const plainPackageResourceResolver = new PackageResourceResolver(
       "./",
       uri,
       tilesetPackage
+    );
+    const packageResourceResolver = new UnzippingResourceResolver(
+      plainPackageResourceResolver
     );
     const tilesetJsonBuffer = await packageResourceResolver.resolveData(
       "tileset.json"


### PR DESCRIPTION
The entries in packages like `.3dtiles` and `.3tz` files may be zipped _individually_. This was not yet anticipated by the validator. Now, resources that are accessed from these packages will be unzipped if they are zipped. 


Corner cases: What should happen if someone puts a `myData.tar.gz` file into such a package, and does it **not** want to be uncompressed transparently? (Related: How can this be made clearer in the spec at https://github.com/CesiumGS/3d-tiles/issues/727 ?)
