### PR TITLE
Update tools to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,21 +23,16 @@
     "3d-tiles-validator": "./build/main"
   },
   "dependencies": {
-    "3d-tiles-tools": "^0.2.0",
-    "archiver": "^5.3.1",
-    "better-sqlite3": "^8.0.1",
+    "3d-tiles-tools": "^0.2.1",
     "cesium": "^1.97.0",
     "gltf-validator": "^2.0.0-dev.3.9",
     "minimatch": "^5.1.0",
     "node-stream-zip": "^1.10.1",
-    "yargs": "^17.5.1",
-    "zlib": "^1.0.5"
+    "yargs": "^17.5.1"
   },
   "devDependencies": {
     "@microsoft/api-documenter": "^7.19.24",
     "@microsoft/api-extractor": "^7.33.6",
-    "@types/archiver": "^5.3.1",
-    "@types/better-sqlite3": "^7.6.2",
     "@types/jasmine": "^4.0.3",
     "@types/minimatch": "^5.1.2",
     "@typescript-eslint/eslint-plugin": "^5.38.0",

--- a/src/validation/PropertiesValidator.ts
+++ b/src/validation/PropertiesValidator.ts
@@ -18,20 +18,66 @@ export class PropertiesValidator {
    * Performs the validation to ensure that the given object is a
    * valid `tileset.properties` object.
    *
+   * Note that the `tileset.properties` is actually a dictionary,
+   * that maps names to `Properties` objects (which, despite
+   * the name, are actually a single property description)
+   *
    * @param properties - The object to validate
    * @param context - The `ValidationContext` that any issues will be added to
    * @returns Whether the object was valid
    */
   static validateProperties(
-    properties: Properties,
+    tilesetProperties: { [key: string]: Properties },
     context: ValidationContext
   ): boolean {
     const path = "/properties";
 
     // Make sure that the given value is an object
     if (
-      !BasicValidator.validateObject(path, "properties", properties, context)
+      !BasicValidator.validateObject(
+        path,
+        "properties",
+        tilesetProperties,
+        context
+      )
     ) {
+      return false;
+    }
+
+    let result = true;
+
+    // Validate all entries of the properties dictionary
+    for (const [key, value] of Object.entries(tilesetProperties)) {
+      // TODO Technically, the key should be validated to be in the batch table...
+      if (PropertiesValidator.validateSingleProperties(key, value, context)) {
+        result = false;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Performs the validation to ensure that the given object is a
+   * valid `Properties` object.
+   *
+   * Note that the `Properties` type (despite the name) represents only
+   * a single property - i.e. one value in the `tileset.properties`
+   * dictionary.
+   *
+   * @param name - The property name
+   * @param properties - The object to validate
+   * @param context - The `ValidationContext` that any issues will be added to
+   * @returns Whether the object was valid
+   */
+  private static validateSingleProperties(
+    name: string,
+    properties: Properties,
+    context: ValidationContext
+  ): boolean {
+    const path = "/properties/" + name;
+
+    // Make sure that the given value is an object
+    if (!BasicValidator.validateObject(path, name, properties, context)) {
       return false;
     }
 
@@ -41,7 +87,7 @@ export class PropertiesValidator {
     if (
       !RootPropertyValidator.validateRootProperty(
         path,
-        "properties",
+        name,
         properties,
         context
       )
@@ -66,45 +112,34 @@ export class PropertiesValidator {
       return result;
     }
 
-    // Validate all entries of the properties dictionary
-    for (const [key, value] of Object.entries(properties)) {
-      // TODO Technically, the key should be validated to be in the batch table...
-      const path = "/properties/" + key;
-
-      // The value MUST be an object
-      if (!BasicValidator.validateObject(path, key, value, context)) {
+    // The minimum and maximum MUST be defined and be numbers
+    const minimum = properties.minimum;
+    const maximum = properties.maximum;
+    const minimumIsValid = BasicValidator.validateNumber(
+      path + "/minimum",
+      "minimum",
+      minimum,
+      context
+    );
+    const maximumIsValid = BasicValidator.validateNumber(
+      path + "/maximum",
+      "maximum",
+      maximum,
+      context
+    );
+    if (minimumIsValid && maximumIsValid) {
+      // The MUST NOT be larger than the maximum
+      if (minimum > maximum) {
+        const message =
+          `The minimum may not be larger than the maximum, ` +
+          `but the minimum is ${minimum} and the maximum is ${maximum}`;
+        const issue =
+          SemanticValidationIssues.PROPERTIES_MINIMUM_LARGER_THAN_MAXIMUM(
+            path,
+            message
+          );
+        context.addIssue(issue);
         result = false;
-      } else {
-        // The minimum and maximum MUST be defined and be numbers
-        const minimum = value.minimum;
-        const maximum = value.maximum;
-        const minimumIsValid = BasicValidator.validateNumber(
-          path + "/minimum",
-          "minimum",
-          minimum,
-          context
-        );
-        const maximumIsValid = BasicValidator.validateNumber(
-          path + "/maximum",
-          "maximum",
-          maximum,
-          context
-        );
-        if (minimumIsValid && maximumIsValid) {
-          // The MUST NOT be larger than the maximum
-          if (minimum > maximum) {
-            const message =
-              `The minimum may not be larger than the maximum, ` +
-              `but the minimum is ${minimum} and the maximum is ${maximum}`;
-            const issue =
-              SemanticValidationIssues.PROPERTIES_MINIMUM_LARGER_THAN_MAXIMUM(
-                path,
-                message
-              );
-            context.addIssue(issue);
-            result = false;
-          }
-        }
       }
     }
     return result;


### PR DESCRIPTION
- Updated the `3d-tiles-tools` to version 0.2.1
- Removed unused dependencies (for things that are no longer required directly, but only indirectly via the tools - namely, `better-sqlite3`, `archiver`, and `zlib`)
- Fixed a wrong typing for `tileset.properties`

The last one was revealed via https://github.com/CesiumGS/3d-tiles-tools/pull/32 : In the manually created `structure` classes, there was a 
```
export interface Tileset extends RootProperty {
  ...
  properties?: Properties;
}
```
but the proper type there is 
`properties?: { [key: string]: Properties };`
(yes, a `Properties` is actually only a single property...)

This does/did not affect the validation (because the validation did not really make assumptions about the structure anyhow). It could only have unexpected effects if someone had added some `extension` into the `tileset.properties`, but I'd have to be reeeally creative to figure out a case of such an unexpected effect...

