### PR TITLE
Update tools to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "3d-tiles-validator": "./build/main"
   },
   "dependencies": {
-    "3d-tiles-tools": "^0.2.1",
+    "3d-tiles-tools": "^0.3.0",
     "cesium": "^1.97.0",
     "gltf-validator": "^2.0.0-dev.3.9",
     "minimatch": "^5.1.0",

--- a/src/validation/metadata/BinaryPropertyTableValidator.ts
+++ b/src/validation/metadata/BinaryPropertyTableValidator.ts
@@ -1028,7 +1028,7 @@ export class BinaryPropertyTableValidator {
       index,
       arrayOffsetType
     );
-    return arrayOffset;
+    return Number(arrayOffset);
   }
   /**
    * Returns the string offset of the given property at the specified
@@ -1065,6 +1065,6 @@ export class BinaryPropertyTableValidator {
       index,
       stringOffsetType
     );
-    return stringOffset;
+    return Number(stringOffset);
   }
 }


### PR DESCRIPTION
For updating the `3d-tiles-tools` to version 0.3.0:

The only change was that the return type of an internal utility function was generalized from `number` to `number | bigint`. Considering that this was used for determining an _array offset_ in an internal utility function (that was called after the actual validation had already taken place), the return value can be converted to `number`. 

