### PR TITLE
Limit number of glTF validation issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+Version ?.?.? - yyyy-mm-dd
+
+- The maximum number of issues that are reported for a single glTF asset is now limited (via [#291](https://github.com/CesiumGS/3d-tiles-validator/pull/291)).
+
 Version 0.5.0 - 2023-10-24
 
 - Added validation of glTF extensions via [#280](https://github.com/CesiumGS/3d-tiles-validator/pull/280) and [#284](https://github.com/CesiumGS/3d-tiles-validator/pull/284). In addition to the basic validation of glTF tile content that is performed with the glTF validator, the 3D Tiles Validator now checks the validity of certain glTF extensions:

--- a/src/tileFormats/GltfValidator.ts
+++ b/src/tileFormats/GltfValidator.ts
@@ -96,6 +96,7 @@ export class GltfValidator implements Validator<Buffer> {
     try {
       gltfResult = await validator.validateBytes(inputWithoutPadding, {
         uri: uri,
+        maxIssues: 1000,
         externalResourceFunction: (gltfUri: string) => {
           const resolvedDataPromise = resourceResolver.resolveData(gltfUri);
           return resolvedDataPromise.then((resolvedData: any) => {

--- a/src/tileFormats/GltfValidator.ts
+++ b/src/tileFormats/GltfValidator.ts
@@ -19,6 +19,15 @@ const validator = require("gltf-validator");
  */
 export class GltfValidator implements Validator<Buffer> {
   /**
+   * The maximum number of issues that should be reported by
+   * the glTF validator. For large glTF assets that contain
+   * "completely invalid" data, a large number of issues
+   * can cause out-of-memory errors.
+   * See https://github.com/CesiumGS/3d-tiles-validator/issues/290
+   */
+  private static readonly MAX_ISSUES = 1000;
+
+  /**
    * Creates a `ValidationIssue` object for the given 'message' object
    * that appears in the output of the glTF validator.
    *
@@ -96,7 +105,7 @@ export class GltfValidator implements Validator<Buffer> {
     try {
       gltfResult = await validator.validateBytes(inputWithoutPadding, {
         uri: uri,
-        maxIssues: 1000,
+        maxIssues: GltfValidator.MAX_ISSUES,
         externalResourceFunction: (gltfUri: string) => {
           const resolvedDataPromise = resourceResolver.resolveData(gltfUri);
           return resolvedDataPromise.then((resolvedData: any) => {
@@ -169,7 +178,6 @@ export class GltfValidator implements Validator<Buffer> {
       );
 
       for (const gltfMessage of gltfResult.issues.messages) {
-        //console.log(gltfMessage);
         const cause =
           GltfValidator.createValidationIssueFromGltfMessage(gltfMessage);
         issue.addCause(cause);
@@ -177,7 +185,8 @@ export class GltfValidator implements Validator<Buffer> {
       context.addIssue(issue);
     }
 
-    // XXX TODO Find a sensible place to hook in glTF extension validators
+    // When the glTF itself is considered to be valid, then perform
+    // the validation of the Cesium glTF metadata extensions
     const extensionsValid =
       await GltfExtensionValidators.validateGltfExtensions(uri, input, context);
     if (!extensionsValid) {


### PR DESCRIPTION
Addresses https://github.com/CesiumGS/3d-tiles-validator/issues/290

glTF tile content is validated with the glTF-Validator. When validating a glTF asset that contains _many_ errors, this can lead to an out-of-memory error. (For example, the GLB in the linked issue would generate roughly 6 million issues...). 

The glTF validator offers an option to limit the number of issues that are reported. It's hard to pick a "universally sensible" value for that. 

(One critical corner case could be that when the limit is set to `x`, then there may be an asset that generates `x` warnings or infos, and the `x+1`th issue would be an 'error', leading to the asset counting as 'valid' even though it isn't...)

This PR just adds a fixed `maxIssues: 1000` for now, which prevents the issue. Questions beyond that are: 

- How many issues should be the default? 
- Should this be configurable from the 3d-tiles-validator side (via validation options in a config file)? 
  - (If yes, some thought would have to go into that. It could be a `maxContentIssues` for _all_ types of content, but only the glTF Validator currently supports such a 'limit'...)


