### PR TITLE
Only issue a warning for channel mismatches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 Version ?.?.? - yyyy-mm-dd
 
 - The maximum number of issues that are reported for a single glTF asset is now limited (via [#291](https://github.com/CesiumGS/3d-tiles-validator/pull/291)).
+- When the number of bytes that are required for a certain feature ID or property texture property did not match the number of `channels`, then the validator reported this as an `ERROR`, with the type `TEXTURE_CHANNELS_OUT_OF_RANGE`. This could cause errors to be reported for the case of 16-bit channels in textures, where these numbers do not have to match. Now, these cases are only reported as a `WARNING`, of the type `TEXTURE_CHANNELS_SIZE_MISMATCH`.
 
 Version 0.5.0 - 2023-10-24
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 Version ?.?.? - yyyy-mm-dd
 
 - The maximum number of issues that are reported for a single glTF asset is now limited (via [#291](https://github.com/CesiumGS/3d-tiles-validator/pull/291)).
-- When the number of bytes that are required for a certain feature ID or property texture property did not match the number of `channels`, then the validator reported this as an `ERROR`, with the type `TEXTURE_CHANNELS_OUT_OF_RANGE`. This could cause errors to be reported for the case of 16-bit channels in textures, where these numbers do not have to match. Now, these cases are only reported as a `WARNING`, of the type `TEXTURE_CHANNELS_SIZE_MISMATCH`.
+- When the number of bytes that are required for a certain property texture property did not match the number of `channels`, then the validator reported this as an `ERROR`, with the type `TEXTURE_CHANNELS_OUT_OF_RANGE`. This could cause errors to be reported for the case of 16-bit channels in textures, where these numbers do not have to match. Now, these cases are only reported as a `WARNING`, of the type `TEXTURE_CHANNELS_SIZE_MISMATCH`.
 
 Version 0.5.0 - 2023-10-24
 

--- a/specs/data/gltfExtensions/structuralMetadata/PropertyTexturePropertyChannelsSizeMismatch.gltf
+++ b/specs/data/gltfExtensions/structuralMetadata/PropertyTexturePropertyChannelsSizeMismatch.gltf
@@ -1,0 +1,170 @@
+{
+  "extensions" : {
+    "EXT_structural_metadata" : {
+      "schema" : {
+        "id": "SimplePropertyTextureSchema",
+        "classes" : {
+          "buildingComponents" : {
+            "name" : "Building properties",
+            "properties" : {
+              "insideTemperature" : {
+                "name" : "Inside Temperature",
+                "type" : "SCALAR",
+                "componentType" : "UINT8"
+              },
+              "outsideTemperature" : {
+                "name" : "Outside Temperature",
+                "type" : "SCALAR",
+                "componentType" : "UINT8"
+              },
+              "insulation" : {
+                "name" : "Insulation Thickness",
+                "type" : "SCALAR",
+                "componentType" : "UINT16",
+                "normalized" : true
+              }
+            }
+          }
+        }
+      },
+      "propertyTextures" : [ {
+        "class" : "buildingComponents",
+        "properties" : {
+          "insideTemperature" : {
+            "index" : 1,
+            "texCoord" : 0,
+            "channels" : [ 0 ]
+          },
+          "outsideTemperature" : {
+            "index" : 1,
+            "texCoord" : 0,
+            "channels" : [ 1 ]
+          },
+          "insulation" : {
+            "index" : 1,
+            "texCoord" : 0,
+            "channels" : [ 2 ]
+          }
+        }
+      } ]
+    }
+  },
+  "extensionsUsed" : [ "EXT_structural_metadata" ],
+  "accessors" : [ {
+    "bufferView" : 0,
+    "byteOffset" : 0,
+    "componentType" : 5123,
+    "count" : 6,
+    "type" : "SCALAR",
+    "max" : [ 3 ],
+    "min" : [ 0 ]
+  }, {
+    "bufferView" : 1,
+    "byteOffset" : 0,
+    "componentType" : 5126,
+    "count" : 4,
+    "type" : "VEC3",
+    "max" : [ 1.0, 1.0, 0.0 ],
+    "min" : [ 0.0, 0.0, 0.0 ]
+  }, {
+    "bufferView" : 2,
+    "byteOffset" : 0,
+    "componentType" : 5126,
+    "count" : 4,
+    "type" : "VEC3",
+    "max" : [ 0.0, 0.0, 1.0 ],
+    "min" : [ 0.0, 0.0, 1.0 ]
+  }, {
+    "bufferView" : 3,
+    "byteOffset" : 0,
+    "componentType" : 5126,
+    "count" : 4,
+    "type" : "VEC2",
+    "max" : [ 1.0, 1.0 ],
+    "min" : [ 0.0, 0.0 ]
+  } ],
+  "asset" : {
+    "generator" : "JglTF from https://github.com/javagl/JglTF",
+    "version" : "2.0"
+  },
+  "buffers" : [ {
+    "uri" : "data:application/gltf-buffer;base64,AAABAAIAAQADAAIAAAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAgD8AAIA/AACAPwAAAAAAAAAAAACAPwAAAAA=",
+    "byteLength" : 140
+  } ],
+  "bufferViews" : [ {
+    "buffer" : 0,
+    "byteOffset" : 0,
+    "byteLength" : 12,
+    "target" : 34963
+  }, {
+    "buffer" : 0,
+    "byteOffset" : 12,
+    "byteLength" : 48,
+    "target" : 34962
+  }, {
+    "buffer" : 0,
+    "byteOffset" : 60,
+    "byteLength" : 48,
+    "target" : 34962
+  }, {
+    "buffer" : 0,
+    "byteOffset" : 108,
+    "byteLength" : 32,
+    "target" : 34962
+  } ],
+  "images" : [ {
+    "uri" : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAIvklEQVR42u3csW5URxsG4BHBRRoklxROEQlSRCJCKShoXFJZiDSpQEqX2pYii8ZVlDZF7oNcAAURDREdpCEXQKoIlAKFEE3O4s0KoV17zxm8Z+Z8j6zvj6Nfj7Q663k968y8aXd3NxtjYk6a/U9OafDwPN+uFwA8LwA8QJ4XAO/Mw26+6Garm6vd/NbzBfA8X79fGQCXuvll/v1P3XzZ8wXwPF+/X+sjwL/zJBm6BeF5vk6/VgC8nG8nhr4Anufr9GsFwA/d/FzwAnier9OfGgC/d/NdwV8heZ6v158YAH908203/wx8ATzP1+1XBsDsL4hfdfNq4H+H5Hm+fr8yAD6Z/Z/vTZ8XwPN8/d5JQJ53EtAD5HkB4AHyfLwAMMboA5CgPO8jgAfI8wLAA+R5fQDuU/O8PgD3qXleH4D71DyvD8B9ap7XB+A+Nc/rA+B5Xh8Az/P6AHie1wfA87w+AJ7nHQXmeV4A8DyvD8AYow+A53kfAXieFwA8z+sD4HleHwDP8/oAeJ7XB8DzvD4Anuf1AfA8rw+A53l9ADzP6wPgeV4fAM/zjgLzPC8AeJ7XB2CMOaEPIBV88TzfrhcAPC8APECeFwDvfj3p5lI3W91c7eZhzxfA83z1fnUA3O7mx/n333fzdc8XwPN89X51AHzazd/z7//s5vOeL4Dn+er96gD4+JR/P+0F8DxfvV8dAOm9f9/q+QJ4nq/e2wHwvB3Akq/Punk5//6v+V8U+7wAnuer96sD4Jv5Xw///yvi7Z4vgOf56v3qAPh1/pfEj+bp8aTnC+B5vnrvJCDPOwnoAfK8APAAeT5eABhj9AFIUJ73EcAD5HkB4AHyfOAAcJ+a5/UBLE4SuU/N85Pz+gB4PrB3G5DnA3t9ADwf2NsB8LwdwJIv96l5fvJeHwDPB/b6AHg+sHcSkOedBPQAeV4AeIA8Hy8AjDH6AMZLsJQHD+83IN/6RwABIAB4ASAABABfSwBs8j7zkh/sK1dyfvw459evc370KOfLl/stoFB+7PePb9bX0Qew5Af76dOcb906/v7OnePF0GcBhfJjv398s76OPoA1trqz34QlW+hJ+7HfP75ZX8dtwBN+8M+dy/nu3Zzv3Ru2gEL4sd8/vllfRx/Aih/+8+dzfvEi5zdvcr55s/8CCuPHfv/4Zn31O4DZ3LiR8/Pnw7fQk/d+A/IffAewyfvM/gbw4f8G4D4830wfwJIf7GfPjv9T2Oz769dzvn+/3wIK5cd+//hmfR19AEt+sK9dO/5PYbPffA8e5HzxYr8FFMqP/f7xzXonAZ0E5J0EFAACgBcAAkAA8PECwBijD8AOwA6A9xFAAAgAXgAIAAHABw4AfQD6AHh9AGkT95n1AegD4Efx+gD0AfCBvT4AfQC824Bp3PvM+gD0AfCjeH0A+gB4O4A07n1mfwPQB8CP4vUB6APgA3t9APoA+MDeSUAnAXknAQWAAOAFgAAQAHy8ADDG6AOwA7AD4H0EEAACgBcAAkAA8IEDQB+APgBeH0DaxH1mfQD6APhRvD4AfQB8YK8PQB8A7zZgGvc+sz4AfQD8KF4fgD4A3g4gjXuf2d8A9AHwo3h9APoA+MBeH4A+AD6wdxLQSUDeSUABIAB4ASAABAAfLwCMMfoAJCjP+wjgAfK8APAAeT5wALhPzfP6ABYnidyn5vnJ+eQ+Nc/H9cltKp6P65P71Dwf19sB8LwdwJIv96l5fvI+uU/N83F9cp+a5+N6JwF53klAD5DnBYAHyPPxAsAYow9AgvK8jwAeIM8LAA+Q5wMHgPvUPK8PYHGSyH1qnp+c1wfA84G924A8H9jrA+D5wN4OgOftAJZ8uU/N85P3+gB4PrDXB8Dzgb2TgDzvJKAHyPMCwAPk+XgBYIzRByBB+UH+6Oho8NTgfQSwAHgBIAAsAF4ACIDjL/ep+TX9qsV1eHiYt7e3By/gTfnI758+AL7YL1tYBwcHeWdn5+2llCELeJM+8vunD4Av9ssW1oULF/Le3t7gBbxJH/n9cxuQL/bLFtb+/v7bfw5dwJv0kd8/fQB8sT9pgQ1dwJv0kd8/OwD+THYAzQeAPoDkPjW/lp9kAOgDSO5T82v5SQaAPoDkPjW/lp9kAOgDcBKOdxLQUWALgBcAAsAC4AXARAPAGKMPwG9A3g7ARwALgBcAAsAC4AVA4ABwH57XB6APYHGSyH14vkcA6ANI+gD4GF4fQLvebUC+2OsDaNfrA+CLvT6Adr0dAH8mOwB9AK3vANyH5/UBTP790wfAF3t9AO16fQB8sdcH0K53EpB3EtBJQAuAFwACwALgBUC8ADDG6APwG5C3A/ARwALgBYAAsAB4ARA4ANyH5/UB6ANYnCRyH57vEQD6AJI+AD6G1wfQrncbkC/2+gDa9foA+GKvD6BdbwfAn8kOQB9A6zsA9+F5fQCTf//0AfDFXh9Au14fAF/s9QG0650E5J0EdBLQAuAFgACwAHgBEC8AjDH6APwG5O0AfASwAHgBIAAsAF4ABA4A9+F5fQD6ABYnidyH53sEgD6ApA+Aj+H1AbTr3Qbki70+gHa9PgC+2OsDaNfbAfBnsgPQB9D6DsB9eF4fwOTfP30AfLHXB9Cu1wfAF3t9AO16JwF5JwGdBLQAeAEgACwAXgDECwBjjD4AvwF5OwAfASwAXgAIAAuAFwCBA8B9eF4fgD6AxUki9+H5HgGgDyDpA+BjeH0A7Xq3Aflirw+gXa8PgC/2+gDa9XYA/JnsAPQBtL4DcB+e1wcw+fdPHwBf7PUBtOv1AfDFXh9Au95JQN5JQCcBLQBeAAgAC4AXAPECwBijD8BvQN4OwEcAC4AXAALAAuAFQOAAcB+e1wegD2Bxksh9eL5HAOgDSPoA+BheH0C73m1AvtjrA2jX6wPgi70+gHa9HQB/JjsAfQCt7wDch+f1AUz+/dMHwBd7fQDten0AfLHXB9CudxKQdxLQSUALgBcAAsAC4AVAqPfvPyVxz6xUBN7bAAAAAElFTkSuQmCC",
+    "mimeType" : "image/png"
+  }, {
+    "uri" : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABLUlEQVR42mVSSxbDIAh0GzUxKZrmCF3n/oerIx9pupgHIswAGtblE7bIKN0vqSOyXSOjPLAtktv9sCFxmcXj7EgsFj8zN00yYxrBZZJBRYk2LdC4WCDUfAdab7bpDm1lCyBW+7lpDnyNS34gcTQRltTPbAeEdFjcSQ0X9EOhGPYjhgLA7xh3kjxEEpMj1qQj7iAzAYoPELzYtuwK02M06WywAFDfX1MdJEoOtSZ7Allz1mYmWZDNL0pNF6ezu9jsQJUcNK7qzbWvMdSYQ8Jo7KKK8/uo4dxreHe0/HgF2/IqBen/za+Di69Sf8cZz5jmk+hcuhdd2tWLz8IE5MbFnRWT+yyU5vZJRtAOqlvq6MDeOrstu0UidsoO0Ak9xGwE+67+34salNEBSCxX7Bexg0rbq6TFvwAAAABJRU5ErkJggg==",
+    "mimeType" : "image/png"
+  } ],
+  "materials" : [ {
+    "pbrMetallicRoughness" : {
+      "baseColorFactor" : [ 1.0, 1.0, 1.0, 1.0 ],
+      "baseColorTexture" : {
+        "index" : 0,
+        "texCoord" : 0
+      },
+      "metallicFactor" : 0.0,
+      "roughnessFactor" : 1.0
+    },
+    "alphaMode" : "OPAQUE",
+    "doubleSided" : true
+  } ],
+  "meshes" : [ {
+    "primitives" : [ {
+      "extensions" : {
+        "EXT_structural_metadata" : {
+          "propertyTextures" : [ 0 ]
+        }
+      },
+      "attributes" : {
+        "POSITION" : 1,
+        "NORMAL" : 2,
+        "TEXCOORD_0" : 3
+      },
+      "indices" : 0,
+      "material" : 0,
+      "mode" : 4
+    } ]
+  } ],
+  "nodes" : [ {
+    "mesh" : 0
+  } ],
+  "samplers" : [ {
+    "magFilter" : 9728,
+    "minFilter" : 9728
+  } ],
+  "scene" : 0,
+  "scenes" : [ {
+    "nodes" : [ 0 ]
+  } ],
+  "textures" : [ {
+    "sampler" : 0,
+    "source" : 0
+  }, {
+    "sampler" : 0,
+    "source" : 1
+  } ]
+}

--- a/specs/gltfExtensions/ExtStructuralMetadataValidationSpec.ts
+++ b/specs/gltfExtensions/ExtStructuralMetadataValidationSpec.ts
@@ -235,6 +235,14 @@ describe("EXT_structural_metadata extension validation", function () {
     expect(result.get(0).type).toEqual("IDENTIFIER_NOT_FOUND");
   });
 
+  it("detects issues in PropertyTexturePropertyChannelsSizeMismatch", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/structuralMetadata/PropertyTexturePropertyChannelsSizeMismatch.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TEXTURE_CHANNELS_SIZE_MISMATCH");
+  });
+
   it("detects issues in PropertyTexturePropertyIndexInvalidType", async function () {
     const result = await validateGltf(
       "./specs/data/gltfExtensions/structuralMetadata/PropertyTexturePropertyIndexInvalidType.gltf"

--- a/src/issues/GltfExtensionValidationIssues.ts
+++ b/src/issues/GltfExtensionValidationIssues.ts
@@ -40,11 +40,10 @@ export class GltfExtensionValidationIssues {
   }
 
   /**
-   * Indicates that the feature ID texture 'channels' property
-   * had a structure that did not match the actual image data,
-   * meaning that the `channels` array contained an element
-   * that was not smaller than the number of actual channels
-   * in the image.
+   * Indicates that the feature ID texture or property texture 'channels'
+   * property had a structure that did not match the actual image data,
+   * meaning that the `channels` array contained an element* that was
+   * not smaller than the number of actual channels in the image.
    *
    * @param path - The path for the `ValidationIssue`
    * @param message - The message for the `ValidationIssue`
@@ -53,6 +52,23 @@ export class GltfExtensionValidationIssues {
   static TEXTURE_CHANNELS_OUT_OF_RANGE(path: string, message: string) {
     const type = "TEXTURE_CHANNELS_OUT_OF_RANGE";
     const severity = ValidationIssueSeverity.ERROR;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that the feature ID texture or property texture 'channels'
+   * property had a structure that will likely not match the expected
+   * data type. For example, when a 16-bit value was represented with
+   * a single channel.
+   *
+   * @param path - The path for the `ValidationIssue`
+   * @param message - The message for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static TEXTURE_CHANNELS_SIZE_MISMATCH(path: string, message: string) {
+    const type = "TEXTURE_CHANNELS_SIZE_MISMATCH";
+    const severity = ValidationIssueSeverity.WARNING;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;
   }

--- a/src/validation/gltfExtensions/PropertyTexturePropertyValidator.ts
+++ b/src/validation/gltfExtensions/PropertyTexturePropertyValidator.ts
@@ -197,8 +197,13 @@ export class PropertyTexturePropertyValidator {
    * the type `STRING`, and has already been determined to be
    * structurally valid.
    *
-   * If the number is not valid, then a validation error will be added
-   * to the given context, and `false` will be returned.
+   * If the number is not valid, then a validation warning will be
+   * added to the given context.
+   *
+   * This makes the assumption that one channel of the image
+   * indeed consists of 8 bits. Since there is no reasonable
+   * way validate the bit depth of the image, any mismatch
+   * will only result in a WARNING (and not an error).
    *
    * @param path - The path for the `ValidationIssue` instances
    * @param propertyName - The name of the property
@@ -239,12 +244,11 @@ export class PropertyTexturePropertyValidator {
             `a total number of ${totalByteSize}, but the number of channels ` +
             `in the property texture property was ${numberOfChannels}`;
           const issue =
-            GltfExtensionValidationIssues.TEXTURE_CHANNELS_OUT_OF_RANGE(
+            GltfExtensionValidationIssues.TEXTURE_CHANNELS_SIZE_MISMATCH(
               path,
               message
             );
           context.addIssue(issue);
-          return false;
         }
       } else {
         // Handle properties that are single enums
@@ -255,12 +259,11 @@ export class PropertyTexturePropertyValidator {
             `consists of ${byteSize} bytes, but the number of channels ` +
             `in the property texture property was ${numberOfChannels}`;
           const issue =
-            GltfExtensionValidationIssues.TEXTURE_CHANNELS_OUT_OF_RANGE(
+            GltfExtensionValidationIssues.TEXTURE_CHANNELS_SIZE_MISMATCH(
               path,
               message
             );
           context.addIssue(issue);
-          return false;
         }
       }
 
@@ -282,12 +285,11 @@ export class PropertyTexturePropertyValidator {
             `ceil(${count}/8) = ${totalByteSize} bytes, but the number of channels ` +
             `in the property texture property was ${numberOfChannels}`;
           const issue =
-            GltfExtensionValidationIssues.TEXTURE_CHANNELS_OUT_OF_RANGE(
+            GltfExtensionValidationIssues.TEXTURE_CHANNELS_SIZE_MISMATCH(
               path,
               message
             );
           context.addIssue(issue);
-          return false;
         }
       }
       // For BOOLEAN properties that are not arrays, even a single
@@ -318,12 +320,11 @@ export class PropertyTexturePropertyValidator {
           `a total number of ${totalByteSize}, but the number of channels ` +
           `in the property texture property was ${numberOfChannels}`;
         const issue =
-          GltfExtensionValidationIssues.TEXTURE_CHANNELS_OUT_OF_RANGE(
+          GltfExtensionValidationIssues.TEXTURE_CHANNELS_SIZE_MISMATCH(
             path,
             message
           );
         context.addIssue(issue);
-        return false;
       }
     } else {
       // Handle properties that are not arrays
@@ -336,12 +337,11 @@ export class PropertyTexturePropertyValidator {
           `the number of channels in the property texture property ` +
           `was ${numberOfChannels}`;
         const issue =
-          GltfExtensionValidationIssues.TEXTURE_CHANNELS_OUT_OF_RANGE(
+          GltfExtensionValidationIssues.TEXTURE_CHANNELS_SIZE_MISMATCH(
             path,
             message
           );
         context.addIssue(issue);
-        return false;
       }
     }
     return true;


### PR DESCRIPTION
Until now, the validator made the assumption that image channels have 8 bits. This means that when someone tried to represent, for example, a 16-bit value in a property texture with a _single_ channel, then the validator generated an `ERROR` with type `TEXTURE_CHANNELS_OUT_OF_RANGE`.

There still are some open questions about the handling of non-8-bit channels in images. Some thoughts and discussion are tracked in https://github.com/CesiumGS/3d-tiles/issues/748 . But for now, the validator should not claim that assets that contain images with 16-bit channels are "invalid". So this PR changes the former `ERROR` in these cases into a `WARNING` with the type `TEXTURE_CHANNELS_SIZE_MISMATCH`. 

The issue will therefore be reported as 
```
        {
          "type": "TEXTURE_CHANNELS_SIZE_MISMATCH",
          "path": "example.glb/propertyTextures/0/properties/exampleProperty",
          "message": "The property 'exampleProperty' has the component type UINT16, with a size of 2 bytes, and the type SCALAR with 1 components, resulting in 2 bytes per element, but the number of channels in the property texture property was 1",
          "severity": "WARNING"
        }
```
but the asset will still be considered to be valid.

