### PR TITLE
Update 3d-tiles-tools to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@gltf-transform/core": "^3.2.1",
     "@gltf-transform/extensions": "^3.2.1",
     "@gltf-transform/functions": "^3.2.1",
-    "3d-tiles-tools": "0.3.1",
+    "3d-tiles-tools": "0.4.1",
     "cesium": "^1.97.0",
     "gltf-validator": "^2.0.0-dev.3.9",
     "minimatch": "^5.1.0",

--- a/src/validation/TilesetPackageValidator.ts
+++ b/src/validation/TilesetPackageValidator.ts
@@ -205,7 +205,7 @@ export class TilesetPackageValidator implements Validator<string> {
 
     const bom = Buffers.getUnicodeBOMDescription(tilesetJsonBuffer);
     if (defined(bom)) {
-      const message = `Unexpected BOM in subtree JSON buffer: ${bom}`;
+      const message = `Unexpected BOM in JSON buffer: ${bom}`;
       const issue = IoValidationIssues.IO_ERROR(uri, message);
       context.addIssue(issue);
       return false;

--- a/src/validation/gltfExtensions/SamplerValidator.ts
+++ b/src/validation/gltfExtensions/SamplerValidator.ts
@@ -83,7 +83,7 @@ export class SamplerValidator {
     let result = true;
     if (!allowedValues.includes(sampler.minFilter)) {
       const message =
-        `The feature ID texture refers to a sampler with 'minFilter' ` +
+        `The texture refers to a sampler with 'minFilter' ` +
         `mode ${sampler.minFilter}, but the filter mode must ` +
         `be one of ${allowedValuesString}`;
 
@@ -93,7 +93,7 @@ export class SamplerValidator {
     }
     if (!allowedValues.includes(sampler.magFilter)) {
       const message =
-        `The feature ID texture refers to a sampler with 'magFilter' ` +
+        `The texture refers to a sampler with 'magFilter' ` +
         `mode ${sampler.minFilter}, but the filter mode must ` +
         `be one of ${allowedValuesString}`;
       const issue = JsonValidationIssues.VALUE_NOT_IN_LIST(path, message);

--- a/src/validation/metadata/MetadataPropertyModel.ts
+++ b/src/validation/metadata/MetadataPropertyModel.ts
@@ -25,7 +25,7 @@ export interface MetadataPropertyModel<K> {
    * The type of the returned object depends on the type of
    * the property:
    * - For `ENUM` properties, it will be a `string` containing
-   *   the name of the repsective enum value (or `undefined`
+   *   the name of the respective enum value (or `undefined`
    *   if the value was not one of the `enum.values[i].value`
    *   values)
    * - For `BOOLEAN` properties, it will be a `boolean`


### PR DESCRIPTION
This replaces https://github.com/CesiumGS/3d-tiles-validator/pull/300 

There have been **no** changes in the "API". 

Except for the version number update in the package JSON, this only replays the smaller ("typo") fixes that had been sneaked into the linked PR, to prevent them from getting lost.
