### PR TITLE
Add result deserialization functionality

### DIFF
--- a/demos/validationResultDemos.ts
+++ b/demos/validationResultDemos.ts
@@ -146,4 +146,17 @@ function validationResultFilterDemo() {
   console.log(ValidationResults.createSimpleResultString(filteredComplex));
 }
 
+function validationResultSerializationDemo() {
+  const result = createDemoResult();
+
+  const serializedJsonString = result.serialize();
+  console.log("Serialized into a JSON string:");
+  console.log(serializedJsonString);
+
+  const deserializedResult = ValidationResult.deserialize(serializedJsonString);
+  console.log("Deserialized from JSON string (simple representation):");
+  console.log(ValidationResults.createSimpleResultString(deserializedResult));
+}
+
 validationResultFilterDemo();
+validationResultSerializationDemo();

--- a/src/validation/ValidationIssue.ts
+++ b/src/validation/ValidationIssue.ts
@@ -158,12 +158,51 @@ export class ValidationIssue {
   }
 
   /**
-   * Creates a JSON string representation of this result
+   * Converts the given JSON object into a `ValidationIssue` instance.
+   *
+   * This does not perform any sanity checks on the given object.
+   * The object is assumed to be one that was created with `toJson`.
+   *
+   * @param object - The object
+   * @returns The `ValidationIssue`
+   */
+  static fromJson(object: any): ValidationIssue {
+    const type = object.type;
+    const path = object.path;
+    const message = object.message;
+    const severity = object.severity;
+    const issue = new ValidationIssue(type, path, message, severity);
+    const causes = object.causes;
+    if (causes != undefined) {
+      for (const cause of causes) {
+        const causeObject = ValidationIssue.fromJson(cause);
+        issue.addCause(causeObject);
+      }
+    }
+    return issue;
+  }
+
+  /**
+   * Creates a JSON string representation of this issue
    *
    * @returns The string representation
    * @internal
    */
   serialize(): string {
     return JSON.stringify(this.toJson(), undefined, 2);
+  }
+
+  /**
+   * Parse a `ValidationIssue` from the given JSON string.
+   *
+   * This does not perform any sanity checks. The given string is assumed
+   * to be in the shape that is created with `serialize`.
+   *
+   * @param jsonString - The JSON string
+   * @returns The `ValidationIssue`
+   */
+  static deserialize(jsonString: string): ValidationIssue {
+    const object = JSON.parse(jsonString);
+    return ValidationIssue.fromJson(object);
   }
 }

--- a/src/validation/ValidationResult.ts
+++ b/src/validation/ValidationResult.ts
@@ -170,6 +170,24 @@ export class ValidationResult {
   }
 
   /**
+   * Converts the given JSON object into a `ValidationResult` instance.
+   *
+   * This does not perform any sanity checks on the given object.
+   * The object is assumed to be one that was created with `toJson`.
+   *
+   * @param object - The object
+   * @returns The `ValidationResult`
+   */
+  static fromJson(object: any) {
+    const result = ValidationResult.create();
+    const issues = object.issues;
+    for (const issue of issues) {
+      result.add(ValidationIssue.fromJson(issue));
+    }
+    return result;
+  }
+
+  /**
    * Creates a JSON string representation of this result.
    *
    * Some details about the format of this result are not yet
@@ -179,5 +197,19 @@ export class ValidationResult {
    */
   serialize(): string {
     return JSON.stringify(this.toJson(), undefined, 2);
+  }
+
+  /**
+   * Parse a `ValidationResult` from the given JSON string.
+   *
+   * This does not perform any sanity checks. The given string is assumed
+   * to be in the shape that is created with `serialize`.
+   *
+   * @param jsonString - The JSON string
+   * @returns The `ValidationResult`
+   */
+  static deserialize(jsonString: string): ValidationResult {
+    const object = JSON.parse(jsonString);
+    return ValidationResult.fromJson(object);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles-validator/issues/306 

Until now, there was no convenient functionality for filtering a `ValidationResult` after it had been written into a report file. This PR adds a simple `deserialize` function, so that it is easier to read a report, filter it, and write out the filtered report:

```typescript
  const data = fs.readFileSync("report.json");
  const result = ValidationResult.deserialize(data.toString());
  const filtered = result.filter(byIncludedSeverities(ERROR, INFO));
  fs.writeFileSync("filtered-report.json", filtered.serialize());
```

  
