### PR TITLE
Validation issue filtering options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,12 +92,11 @@ const argv = args.argv;
 async function readOptionsFile(
   optionsFile: string
 ): Promise<ValidationOptions> {
-  const validationOptions: ValidationOptions = await readJsonUnchecked(
-    optionsFile
-  );
-  if (!validationOptions) {
+  const validationOptionsObject = await readJsonUnchecked(optionsFile);
+  if (!validationOptionsObject) {
     return new ValidationOptions();
   }
+  const validationOptions = ValidationOptions.fromJson(validationOptionsObject);
   return validationOptions;
 }
 

--- a/src/validation/ContentDataValidator.ts
+++ b/src/validation/ContentDataValidator.ts
@@ -15,6 +15,8 @@ import { Content } from "3d-tiles-tools";
 import { IoValidationIssues } from "../issues/IoValidationIssue";
 import { ContentValidationIssues } from "../issues/ContentValidationIssues";
 import { ValidationOptionChecks } from "./ValidationOptionChecks";
+import { ValidationIssueFilters } from "./ValidationIssueFilters";
+import { ValidationIssueSeverity } from "./ValidationIssueSeverity";
 
 /**
  * A class for validation of the data that is pointed to by a `content.uri`.
@@ -183,9 +185,29 @@ export class ContentDataValidator {
         context.addIssue(issue);
       }
     } else {
+      const includedSeverities: ValidationIssueSeverity[] = [];
+      if (
+        options.contentValidationIssueSeverity == ValidationIssueSeverity.ERROR
+      ) {
+        includedSeverities.push(ValidationIssueSeverity.ERROR);
+      } else if (
+        options.contentValidationIssueSeverity ==
+        ValidationIssueSeverity.WARNING
+      ) {
+        includedSeverities.push(ValidationIssueSeverity.WARNING);
+        includedSeverities.push(ValidationIssueSeverity.ERROR);
+      } else {
+        includedSeverities.push(ValidationIssueSeverity.INFO);
+        includedSeverities.push(ValidationIssueSeverity.WARNING);
+        includedSeverities.push(ValidationIssueSeverity.ERROR);
+      }
+      const filter = ValidationIssueFilters.byIncludedSeverities(
+        ...includedSeverities
+      );
+      const filteredDerivedResult = derivedResult.filter(filter);
       const issue = ContentValidationIssues.createForContent(
         contentUri,
-        derivedResult
+        filteredDerivedResult
       );
       if (issue) {
         context.addIssue(issue);

--- a/src/validation/ValidationOptions.ts
+++ b/src/validation/ValidationOptions.ts
@@ -1,3 +1,5 @@
+import { ValidationIssueSeverity } from "./ValidationIssueSeverity";
+
 /**
  * A class describing the options for a validator within
  * a `ValidationContext`
@@ -13,6 +15,12 @@ export class ValidationOptions {
    * Whether content data should be validated at all.
    */
   private _validateContentData: boolean;
+
+  /**
+   * The severity of content validation issues that should be
+   * included in the results.
+   */
+  private _contentValidationIssueSeverity: ValidationIssueSeverity;
 
   /**
    * The content types that are included in the validation.
@@ -37,6 +45,7 @@ export class ValidationOptions {
    */
   constructor() {
     this._validateContentData = true;
+    this._contentValidationIssueSeverity = ValidationIssueSeverity.INFO;
     this._includeContentTypes = undefined;
     this._excludeContentTypes = undefined;
   }
@@ -52,6 +61,23 @@ export class ValidationOptions {
 
   set validateContentData(value: boolean) {
     this._validateContentData = value;
+  }
+
+  /**
+   * The severity of content validation issues that should
+   * be included in the result.
+   *
+   * By default, this will be `INFO`, meaning that all content
+   * validation issues will be included. It can be set to
+   * `WARNING`, to include all `ERROR` and `WARNING` issues,
+   * or to `ERROR` to only include `ERROR` issues.
+   */
+  get contentValidationIssueSeverity(): ValidationIssueSeverity {
+    return this._contentValidationIssueSeverity;
+  }
+
+  set contentValidationIssueSeverity(value: ValidationIssueSeverity) {
+    this._contentValidationIssueSeverity = value;
   }
 
   /**

--- a/src/validation/Validators.ts
+++ b/src/validation/Validators.ts
@@ -458,6 +458,33 @@ export class Validators {
       );
     }
 
+    // Register an empty validator for NGA_gpm
+    {
+      const emptyValidator = Validators.createEmptyValidator();
+      const override = false;
+      ExtendedObjectsValidators.register("NGA_gpm", emptyValidator, override);
+    }
+    // Register an empty validator for MAXAR_extent
+    {
+      const emptyValidator = Validators.createEmptyValidator();
+      const override = false;
+      ExtendedObjectsValidators.register(
+        "MAXAR_extent",
+        emptyValidator,
+        override
+      );
+    }
+    // Register an empty validator for MAXAR_grid
+    {
+      const emptyValidator = Validators.createEmptyValidator();
+      const override = false;
+      ExtendedObjectsValidators.register(
+        "MAXAR_grid",
+        emptyValidator,
+        override
+      );
+    }
+
     Validators._registeredExtensionValidators = true;
   }
 }

--- a/src/validation/gltfExtensions/GltfDataReader.ts
+++ b/src/validation/gltfExtensions/GltfDataReader.ts
@@ -1,5 +1,7 @@
-import { JSONDocument } from "@gltf-transform/core";
 import { Document } from "@gltf-transform/core";
+import { JSONDocument } from "@gltf-transform/core";
+import { Logger } from "@gltf-transform/core";
+import { Verbosity } from "@gltf-transform/core";
 
 import { BinaryBufferData } from "3d-tiles-tools";
 import { BinaryBufferDataResolver } from "3d-tiles-tools";
@@ -155,6 +157,8 @@ export class GltfDataReader {
   ): Promise<Document | undefined> {
     try {
       const io = await GltfTransform.getIO();
+      // Avoid warning "Missing optional extension"
+      io.setLogger(new Logger(Verbosity.ERROR));
       const gltfDocument = await io.readBinary(input);
       return gltfDocument;
     } catch (error) {
@@ -236,6 +240,8 @@ export class GltfDataReader {
     const resources = {};
     try {
       const io = await GltfTransform.getIO();
+      // Avoid warning "Missing optional extension"
+      io.setLogger(new Logger(Verbosity.ERROR));
       const json = JSON.parse(input.toString());
       const jsonDoc = { json, resources } as JSONDocument;
       const gltfDocument = await io.readJSON(jsonDoc);


### PR DESCRIPTION
When validating a tileset with many contents, then the glTF-Validator will be applied to _each_ content. Depending on the nature of the glTF files, this may cause a lot of noise. For example, when the glTF files contain certain extensions that are not handled by the glTF validator, then this will usually cause ...
- WARNING: "Extension uses unreserved extension prefix..."
- INFO: "Cannot validate an extension as it is not supported by the validator..."
- INFO: "This object may be unused..." (when the extension defines its own data objects)

for **each and every content**.

The `ValidationResult.filter` function (as [described in the README](https://github.com/CesiumGS/3d-tiles-validator?tab=readme-ov-file#validaton-result-filtering)) already offers some options for filtering validation results _post-hoc_. However, there is currently no way to define fine-grained filtering options directly at the command line. Such filters _might_ be arbitrarily complex, and therefore, there will hardly be a way to squeeze these into configuration- or option files (except for some simple, special cases) - and even less, define them at the command line.

However, there are some ways of how one could reduce the amount of noise here, with relatively little effort.

This PR currently implements an additional `ValidationOption` property caled `contentValidationIssueSeverity`. This defines a filter criterion for the `CONTENT_VALIDATION_[INFO/WARNING/ERROR]` family of issues that is applied during the validation itself. This validation option can (like all validation options) be part of an "options file" that is passed in at the command line.

For example, with 
`npx ts-node ./src/main.ts --tilesetFile "C:\Data\tileset.json" --optionsFile gltfSilencingOptions.json`
and a file `gltfSilencingOptions.json` that just contains
```json
{
  "contentValidationIssueSeverity": "ERROR"
}
```
the validator will no longer include content validation INFO- or WARNING issues in the result.

---

One could consider more fine-grained control here. For example, users might wish to filter out certain issues from the glTF-Validator in particular, based on the `type` that the issues have there. For example, they might want to filter out only `BUFFER_VIEW_INVALID_BYTE_STRIDE` issues or so. This is currently _not_ possible (and would require a few structural changes), because these types are _not_ preserved: The 3D Tiles validator defines its own set of "issue types", and does _not_ pass through these types (so they are all converted into `CONTENT_VALIDATION_[INFO/WARNING/ERROR]` issues internally)

---

Note: This PR does two things to reduce the noise that are unrelated to the content validation issue filtering:
- It disables the "Missing optional extension" log output from glTF-Transform
- It adds "empty" validators for the `NGA_gpm`, `MAXAR_extent`, and `MAXAR_grid` 3D Tiles extensions, meaning that the presence of these extensions will no longer cause any issues to be reported