### PR TITLE
Update 3D Tiles Tools to 0.4.2

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -4,7 +4,7 @@
     "license": [
       "Apache-2.0"
     ],
-    "version": "0.3.1",
+    "version": "0.4.2",
     "url": "https://www.npmjs.com/package/3d-tiles-tools"
   },
   {
@@ -12,7 +12,7 @@
     "license": [
       "MIT"
     ],
-    "version": "3.7.4",
+    "version": "3.10.1",
     "url": "https://www.npmjs.com/package/@gltf-transform/core"
   },
   {
@@ -20,7 +20,7 @@
     "license": [
       "MIT"
     ],
-    "version": "3.7.4",
+    "version": "3.10.1",
     "url": "https://www.npmjs.com/package/@gltf-transform/extensions"
   },
   {
@@ -28,7 +28,7 @@
     "license": [
       "MIT"
     ],
-    "version": "3.7.4",
+    "version": "3.10.1",
     "url": "https://www.npmjs.com/package/@gltf-transform/functions"
   },
   {
@@ -36,7 +36,7 @@
     "license": [
       "Apache-2.0"
     ],
-    "version": "1.104.0",
+    "version": "1.117.0",
     "url": "https://www.npmjs.com/package/cesium"
   },
   {

--- a/etc/3d-tiles-validator.api.md
+++ b/etc/3d-tiles-validator.api.md
@@ -18,6 +18,8 @@ export class ValidationIssue {
     // @internal
     addCause(cause: ValidationIssue): void;
     get causes(): readonly ValidationIssue[];
+    static deserialize(jsonString: string): ValidationIssue;
+    static fromJson(object: any): ValidationIssue;
     get message(): string;
     get path(): string;
     // @internal
@@ -47,6 +49,8 @@ export enum ValidationIssueSeverity {
 // @beta
 export class ValidationOptions {
     constructor();
+    get contentValidationIssueSeverity(): ValidationIssueSeverity;
+    set contentValidationIssueSeverity(value: ValidationIssueSeverity);
     get excludeContentTypes(): string[] | undefined;
     set excludeContentTypes(value: string[] | undefined);
     static fromJson(json: any): ValidationOptions;
@@ -62,7 +66,9 @@ export class ValidationResult {
     add(issue: ValidationIssue): void;
     // @internal
     static create(): ValidationResult;
+    static deserialize(jsonString: string): ValidationResult;
     filter(includePredicate: ValidationIssueFilter): ValidationResult;
+    static fromJson(object: any): ValidationResult;
     get(index: number): ValidationIssue;
     get issues(): readonly ValidationIssue[];
     get length(): number;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@gltf-transform/core": "^3.2.1",
     "@gltf-transform/extensions": "^3.2.1",
     "@gltf-transform/functions": "^3.2.1",
-    "3d-tiles-tools": "0.4.1",
+    "3d-tiles-tools": "0.4.2",
     "cesium": "^1.97.0",
     "gltf-validator": "^2.0.0-dev.3.9",
     "minimatch": "^5.1.0",


### PR DESCRIPTION
This only updates the 3D Tiles Tools to the latest released version 0.4.2.

It includes an update for the auto-generated API file. This does affect some parts of the API that are marked as `@beta`, mainly the  `contentValidationIssueSeverity` option that was added in https://github.com/CesiumGS/3d-tiles-validator/pull/310 . This is **not** yet mentioned in the README.md, because it might still change, depending on the feedback. Updating the README.md with information about this setting will be part of preparing a new release of the validator.
