### PR TITLE
Subtree buffer structure validation

### DIFF
--- a/specs/BinaryBufferStructureSpec.ts
+++ b/specs/BinaryBufferStructureSpec.ts
@@ -42,7 +42,8 @@ function performTestValidation(
   if (
     BinaryBufferStructureValidator.validateBinaryBufferStructure(
       path,
-      binaryBufferStructure,
+      binaryBufferStructure.buffers,
+      binaryBufferStructure.bufferViews,
       firstBufferUriIsRequired,
       context
     )

--- a/specs/SubtreeValidationSpec.ts
+++ b/specs/SubtreeValidationSpec.ts
@@ -9,20 +9,22 @@ import { ValidationResult } from "../src/validation/ValidationResult";
 /**
  * Validate the specified subtree file from the `specs/data/subtrees`
  * directory.
- * 
+ *
  * Note that in order to validate a subtree file, the validator requires
- * additional data elements. Namely, the `TileImplicitTiling` that 
+ * additional data elements. Namely, the `TileImplicitTiling` that
  * defines the structure of the subtree, and a `Schema` (if the
  * subtree contains metadata).
- * 
+ *
  * This function will load this data from the additional files in
  * the `specs/data/` directory that define the same structure for
  * all subtree spec files.
- * 
+ *
  * @param fileName - The subtree file name
  * @returns A promise to the `ValidationResult`
  */
-async function validateSpecSubtreeFile(fileName: string): Promise<ValidationResult> {
+async function validateSpecSubtreeFile(
+  fileName: string
+): Promise<ValidationResult> {
   // The schema for the subtrees in the specs directory
   const specSchema: Schema = await readJsonUnchecked(
     "specs/data/schemas/validSchema.json"
@@ -45,7 +47,6 @@ async function validateSpecSubtreeFile(fileName: string): Promise<ValidationResu
   );
   return validationResult;
 }
-
 
 describe("Subtree validation", function () {
   it("detects issues in binarySubtreeComputedLengthInvalid", async function () {
@@ -388,5 +389,4 @@ describe("Subtree validation", function () {
     );
     expect(result.length).toEqual(0);
   });
-
 });

--- a/specs/SubtreeValidationSpec.ts
+++ b/specs/SubtreeValidationSpec.ts
@@ -1,0 +1,392 @@
+import { Schema } from "3d-tiles-tools";
+
+import { readJsonUnchecked } from "../src/base/readJsonUnchecked";
+
+import { Validators } from "../src/validation/Validators";
+import { ValidatedElement } from "../src/validation/ValidatedElement";
+import { ValidationResult } from "../src/validation/ValidationResult";
+
+/**
+ * Validate the specified subtree file from the `specs/data/subtrees`
+ * directory.
+ * 
+ * Note that in order to validate a subtree file, the validator requires
+ * additional data elements. Namely, the `TileImplicitTiling` that 
+ * defines the structure of the subtree, and a `Schema` (if the
+ * subtree contains metadata).
+ * 
+ * This function will load this data from the additional files in
+ * the `specs/data/` directory that define the same structure for
+ * all subtree spec files.
+ * 
+ * @param fileName - The subtree file name
+ * @returns A promise to the `ValidationResult`
+ */
+async function validateSpecSubtreeFile(fileName: string): Promise<ValidationResult> {
+  // The schema for the subtrees in the specs directory
+  const specSchema: Schema = await readJsonUnchecked(
+    "specs/data/schemas/validSchema.json"
+  );
+  const specSchemaState: ValidatedElement<Schema> = {
+    wasPresent: true,
+    validatedElement: specSchema,
+  };
+
+  // The `TileImplicitTiling` object that defines the
+  // structure of subtrees in the specs directory
+  const specImplicitTiling = await readJsonUnchecked(
+    "specs/data/subtrees/validSubtreeImplicitTiling.json.input"
+  );
+
+  const validationResult = await Validators.validateSubtreeFile(
+    fileName,
+    specSchemaState,
+    specImplicitTiling
+  );
+  return validationResult;
+}
+
+
+describe("Subtree validation", function () {
+  it("detects issues in binarySubtreeComputedLengthInvalid", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/binarySubtreeComputedLengthInvalid.subtree"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("BINARY_INVALID_LENGTH");
+  });
+
+  it("detects issues in binarySubtreeInvalidBinaryByteLengthAlignment", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/binarySubtreeInvalidBinaryByteLengthAlignment.subtree"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("BINARY_INVALID_ALIGNMENT");
+  });
+
+  it("detects issues in binarySubtreeInvalidJsonByteLengthAlignment", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/binarySubtreeInvalidJsonByteLengthAlignment.subtree"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("BINARY_INVALID_ALIGNMENT");
+  });
+
+  it("detects issues in binarySubtreeInvalidMagic", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/binarySubtreeInvalidMagic.subtree"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("IO_ERROR");
+  });
+
+  it("detects issues in binarySubtreeInvalidVersion", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/binarySubtreeInvalidVersion.subtree"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("BINARY_INVALID_VALUE");
+  });
+
+  it("detects issues in binarySubtreeJsonInvalid", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/binarySubtreeJsonInvalid.subtree"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("JSON_PARSE_ERROR");
+  });
+
+  it("detects no issues in binarySubtreeValid", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/binarySubtreeValid.subtree"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("detects issues in subtreeBufferViewsWithoutBuffers", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeBufferViewsWithoutBuffers.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("BUFFER_VIEWS_WITHOUT_BUFFERS");
+  });
+
+  it("detects issues in subtreeChildSubtreeAvailabilityInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeChildSubtreeAvailabilityInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeChildSubtreeAvailabilityMissing", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeChildSubtreeAvailabilityMissing.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("PROPERTY_MISSING");
+  });
+
+  it("detects issues in subtreeContentAvailabilityInvalidLength", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeContentAvailabilityInvalidLength.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_LENGTH_MISMATCH");
+  });
+
+  it("detects issues in subtreeContentAvailabilityInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeContentAvailabilityInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeContentMetadataArrayElementInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeContentMetadataArrayElementInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_ELEMENT_TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeContentMetadataArrayElementInvalidValueA", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeContentMetadataArrayElementInvalidValueA.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeContentMetadataArrayElementInvalidValueB", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeContentMetadataArrayElementInvalidValueB.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_RANGE");
+  });
+
+  it("detects issues in subtreeContentMetadataInvalidLength", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeContentMetadataInvalidLength.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_LENGTH_MISMATCH");
+  });
+
+  it("detects issues in subtreeContentMetadataInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeContentMetadataInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeContentMetadataWithoutPropertyTables", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeContentMetadataWithoutPropertyTables.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("REQUIRED_VALUE_NOT_FOUND");
+  });
+
+  it("detects issues in subtreePropertyTablesElementInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreePropertyTablesElementInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_ELEMENT_TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreePropertyTablesInvalidLength", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreePropertyTablesInvalidLength.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_LENGTH_MISMATCH");
+  });
+
+  it("detects issues in subtreePropertyTablesInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreePropertyTablesInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeTileAvailabilityAvailableCountInvalid", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityAvailableCountInvalid.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("SUBTREE_AVAILABILITY_INCONSISTENT");
+  });
+
+  it("detects issues in subtreeTileAvailabilityAvailableCountMismatch", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityAvailableCountMismatch.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("SUBTREE_AVAILABILITY_INCONSISTENT");
+  });
+
+  it("detects issues in subtreeTileAvailabilityBitstreamAndConstant", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityBitstreamAndConstant.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ONE_OF_ERROR");
+  });
+
+  it("detects issues in subtreeTileAvailabilityBitstreamInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityBitstreamInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeTileAvailabilityBitstreamInvalidValueA", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityBitstreamInvalidValueA.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeTileAvailabilityBitstreamInvalidValueB", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityBitstreamInvalidValueB.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_RANGE");
+  });
+
+  it("detects issues in subtreeTileAvailabilityBitstreamInvalidValueC", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityBitstreamInvalidValueC.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_RANGE");
+  });
+
+  it("detects issues in subtreeTileAvailabilityBitstreamLengthTooLarge", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityBitstreamLengthTooLarge.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("SUBTREE_AVAILABILITY_INCONSISTENT");
+  });
+
+  it("detects issues in subtreeTileAvailabilityBitstreamLengthTooSmall", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityBitstreamLengthTooSmall.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("SUBTREE_AVAILABILITY_INCONSISTENT");
+  });
+
+  it("detects issues in subtreeTileAvailabilityConstantInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityConstantInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_LIST");
+  });
+
+  it("detects issues in subtreeTileAvailabilityConstantInvalidValue", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityConstantInvalidValue.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_LIST");
+  });
+
+  it("detects issues in subtreeTileAvailabilityForParentMissingForAvailableTile", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityForParentMissingForAvailableTile.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("SUBTREE_AVAILABILITY_INCONSISTENT");
+  });
+
+  it("detects issues in subtreeTileAvailabilityInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeTileAvailabilityMissing", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityMissing.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("PROPERTY_MISSING");
+  });
+
+  it("detects issues in subtreeTileAvailabilityMissingForAvailableContent", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityMissingForAvailableContent.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("SUBTREE_AVAILABILITY_INCONSISTENT");
+  });
+
+  it("detects issues in subtreeTileAvailabilityNeitherBitstreamNorConstant", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileAvailabilityNeitherBitstreamNorConstant.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ANY_OF_ERROR");
+  });
+
+  it("detects issues in subtreeTileMetadataInvalidType", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileMetadataInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeTileMetadataInvalidValueA", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileMetadataInvalidValueA.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in subtreeTileMetadataInvalidValueB", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/subtreeTileMetadataInvalidValueB.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_RANGE");
+  });
+
+  it("detects no issues in validSubtree", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/validSubtree.json"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("detects issues in validSubtreeBuffersWithoutBufferViews", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/validSubtreeBuffersWithoutBufferViews.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("BUFFERS_WITHOUT_BUFFER_VIEWS");
+  });
+
+  it("detects no issues in validSubtreeNoBuffers", async function () {
+    const result = await validateSpecSubtreeFile(
+      "specs/data/subtrees/validSubtreeNoBuffers.json"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+});

--- a/specs/data/subtrees/subtreeBufferViewsWithoutBuffers.json
+++ b/specs/data/subtrees/subtreeBufferViewsWithoutBuffers.json
@@ -1,0 +1,9 @@
+{
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0, "byteLength": 3 },
+    { "buffer": 0, "byteOffset": 8, "byteLength": 8 }
+  ],
+  "tileAvailability": { "bitstream": 0, "availableCount": 7 },
+  "contentAvailability": [{ "availableCount": 0, "constant": 0 }],
+  "childSubtreeAvailability": { "bitstream": 1, "availableCount": 8 }
+}

--- a/specs/data/subtrees/validSubtreeBuffersWithoutBufferViews.json
+++ b/specs/data/subtrees/validSubtreeBuffersWithoutBufferViews.json
@@ -1,0 +1,6 @@
+{
+  "buffers": [{ "uri": "validBuffer.bin", "byteLength": 16 }],
+  "tileAvailability": { "constant": 1 },
+  "contentAvailability": [{ "constant": 1 }],
+  "childSubtreeAvailability": { "constant": 0 }
+}

--- a/specs/data/subtrees/validSubtreeNoBuffers.json
+++ b/specs/data/subtrees/validSubtreeNoBuffers.json
@@ -1,0 +1,5 @@
+{
+  "tileAvailability": { "constant": 1 },
+  "contentAvailability": [{ "constant": 1 }],
+  "childSubtreeAvailability": { "constant": 0 }
+}

--- a/src/issues/SemanticValidationIssues.ts
+++ b/src/issues/SemanticValidationIssues.ts
@@ -229,7 +229,7 @@ export class SemanticValidationIssues {
    * Indicates an inconsistency of buffers and buffer views.
    *
    * This mainly refers to the 'buffers' and 'bufferViews' of
-   * an implicit subtree. It may, for example, inciate that a
+   * an implicit subtree. It may, for example, indicate that a
    * buffer view does not fit into the buffer that it refers to.
    *
    * @param path - The path for the `ValidationIssue`
@@ -238,6 +238,39 @@ export class SemanticValidationIssues {
    */
   static BUFFERS_INCONSISTENT(path: string, message: string) {
     const type = "BUFFERS_INCONSISTENT";
+    const severity = ValidationIssueSeverity.ERROR;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a binary buffer structure (like the 'buffers' and
+   * 'bufferViews' of a subtree) contained `buffers`, but no `bufferViews`.
+   *
+   * This is only a WARNING, because it does not violate the specification,
+   * but is certainly not intended.
+   *
+   * @param path - The path for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static BUFFERS_WITHOUT_BUFFER_VIEWS(path: string) {
+    const type = "BUFFERS_WITHOUT_BUFFER_VIEWS";
+    const message = "The object contained 'buffers' but no 'bufferViews'";
+    const severity = ValidationIssueSeverity.WARNING;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
+   * Indicates that a binary buffer structure (like the 'buffers' and
+   * 'bufferViews' of a subtree) contained `bufferViews`, but no `buffers`
+   *
+   * @param path - The path for the `ValidationIssue`
+   * @returns The `ValidationIssue`
+   */
+  static BUFFER_VIEWS_WITHOUT_BUFFERS(path: string) {
+    const type = "BUFFER_VIEWS_WITHOUT_BUFFERS";
+    const message = "The object contained 'bufferViews' but no 'buffers'";
     const severity = ValidationIssueSeverity.ERROR;
     const issue = new ValidationIssue(type, path, message, severity);
     return issue;

--- a/src/validation/SubtreeConsistencyValidator.ts
+++ b/src/validation/SubtreeConsistencyValidator.ts
@@ -24,7 +24,9 @@ import { BinaryBufferStructure } from "3d-tiles-tools";
  * and availability data, referring to the information that is
  * given in the `TileImplicitTiling` structure.
  *
- * They will **NOT** analyze the actual buffer data.
+ * They will **NOT** analyze the actual buffer data. If the subtree
+ * data is consistent, then the actual buffer data is validated based
+ * on the high-level (model) objects, using a `SubtreeInfoValidator`.
  *
  * @internal
  */
@@ -52,21 +54,25 @@ export class SubtreeConsistencyValidator {
     implicitTiling: TileImplicitTiling | undefined,
     context: ValidationContext
   ): boolean {
-    // Only if the buffers and buffer views have been valid
-    // on the JSON level, validate their consistency
-    // in terms of memory layout
-    const binaryBufferStructure: BinaryBufferStructure = {
-      buffers: subtree.buffers ?? [],
-      bufferViews: subtree.bufferViews ?? [],
-    };
-    if (
-      !BinaryBufferStructureValidator.validateBinaryBufferStructureConsistency(
-        path,
-        binaryBufferStructure,
-        context
-      )
-    ) {
-      return false;
+    // The buffers and bufferViews are optional. If they are both defined,
+    // then the SubtreeValidator already validated them on the JSON level.
+    // Here, validate their consistency in terms of memory layout
+    const buffers = subtree.buffers;
+    const bufferViews = subtree.bufferViews;
+    if (defined(buffers) && defined(bufferViews)) {
+      const binaryBufferStructure: BinaryBufferStructure = {
+        buffers: buffers,
+        bufferViews: bufferViews,
+      };
+      if (
+        !BinaryBufferStructureValidator.validateBinaryBufferStructureConsistency(
+          path,
+          binaryBufferStructure,
+          context
+        )
+      ) {
+        return false;
+      }
     }
 
     if (defined(implicitTiling)) {

--- a/src/validation/SubtreeValidator.ts
+++ b/src/validation/SubtreeValidator.ts
@@ -228,13 +228,13 @@ export class SubtreeValidator implements Validator<Buffer> {
     // and bufferViews. When they are invalid, then the binary
     // subtree data cannot be resolved, and the subtree is
     // considered to be invalid.
-    const hasBinaryBuffer = binaryByteLength > 0;
+    const firstBufferUriIsRequired = binaryByteLength === 0n;
     const bufferStructureValid =
       BinaryBufferStructureValidator.validateBinaryBufferStructure(
         path,
         subtree.buffers,
         subtree.bufferViews,
-        hasBinaryBuffer,
+        firstBufferUriIsRequired,
         context
       );
     if (!bufferStructureValid) {
@@ -279,13 +279,13 @@ export class SubtreeValidator implements Validator<Buffer> {
       // and bufferViews. When they are invalid, then the binary
       // subtree data cannot be resolved, and the subtree is
       // considered to be invalid.
-      const hasBinaryBuffer = false;
+      const firstBufferUriIsRequired = true;
       const bufferStructureValid =
         BinaryBufferStructureValidator.validateBinaryBufferStructure(
           path,
           subtree.buffers,
           subtree.bufferViews,
-          hasBinaryBuffer,
+          firstBufferUriIsRequired,
           context
         );
       if (!bufferStructureValid) {


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles-validator/issues/312 

Additionally, I have added the subtree validation to the specs. Some details are described in https://github.com/CesiumGS/3d-tiles-validator/issues/226 , but the **tl;dr** is:

- There had been subtree files in `specs/data/subtrees/`. These had not been part of the specs (for reeasons mentioned in the linked issue). They could only be validated with the (internal) `--subtreeSpecs` command line command.
- Now, they are validated in the same way as the tilesets in the `specs/data`: The `SubtreeValidationSpec` just validates all these files (using the fixed subtree 'implicit tiling' structure that all of these files have!) and checks whether the proper validation messages are generated.

This includes the check that the [`validSubtreeNoBuffers.json`](https://github.com/CesiumGS/3d-tiles-validator/blob/9528804dad6f36ffc5fafe1230fe36bb7a9f5f18/specs/data/subtrees/validSubtreeNoBuffers.json) (based on https://github.com/CesiumGS/3d-tiles-validator/issues/312) does _not_ generate any issues. 

