### PR TITLE
Apply transform to content bounding volume

### DIFF
--- a/specs/TilesetValidationSpec.ts
+++ b/specs/TilesetValidationSpec.ts
@@ -417,6 +417,13 @@ describe("Tileset validation", function () {
     expect(result.get(0).type).toEqual("BOUNDING_VOLUMES_INCONSISTENT");
   });
 
+  it("detects no issues in tileContentBoundingVolumeWithTransform", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/tilesets/tileContentBoundingVolumeWithTransform.json"
+    );
+    expect(result.length).toEqual(0);
+  });
+
   it("detects issues in tileContentGroupInvalidIndex", async function () {
     const result = await Validators.validateTilesetFile(
       "specs/data/tilesets/tileContentGroupInvalidIndex.json"

--- a/specs/data/tilesets/tileContentBoundingVolumeWithTransform.json
+++ b/specs/data/tilesets/tileContentBoundingVolumeWithTransform.json
@@ -1,0 +1,25 @@
+{
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "transform": [
+      2.0, 0.0, 0.0, 0.0,
+      0.0, 3.0, 0.0, 0.0,
+      0.0, 0.0, 4.0, 0.0,
+      5.0, 6.0, 7.0, 1.0
+    ],
+    "content": {
+      "uri": "tiles/glTF/Triangle/Triangle.gltf",
+      "boundingVolume": {
+        "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+      }
+    }
+  }
+}

--- a/src/validation/TileContentValidator.ts
+++ b/src/validation/TileContentValidator.ts
@@ -96,7 +96,7 @@ export class TileContentValidator {
     }
     const tileBoundingVolume = tile.boundingVolume;
     const outerTransform = tile.transform;
-    const innerTransform = undefined;
+    const innerTransform = tile.transform;
     const errorMessage = BoundingVolumeChecks.checkBoundingVolume(
       contentBoundingVolume,
       tileBoundingVolume,


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles-validator/issues/321 

When there was a tile with a `transform`, and `content` that had a `boundingVolume`, then the `transform` was only applied to the _tile_ bounding volume, but not to the _content_ bounding volume. This was a leftover from [the original/"legacy" bounding volume checks](https://github.com/CesiumGS/3d-tiles-validator/blob/e84202480eb6572383008076150c8e52c99af3c3/validator/lib/validateTileset.js#L109), and caused a `BOUNDING_VOLUMES_INCONSISTENT` to be reported erroneously. 

Fortunately, it was an easy fix.

I did add a test for the case of bounding `box` objects. But in general, some parts of the "legacy" bounding volume containment checks could receive some additional coverage. It would be nice to cover the whole cartesian product of

- `box` and `box`
- `box` and `sphere`
- `box` and `region`
- `sphere` and `box`
- `sphere` and `sphere`
- `sphere` and `region`
- `region` and `box`
- `region` and `sphere`
- `region` and `region`

both with and without `transform`, and a _positive_ and a _negative_ case, respectively. But I'd have to allocate more time to actually create these 36 tilesets...


