### PR TITLE
Update 3D Tiles Tools to 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@gltf-transform/core": "^3.2.1",
     "@gltf-transform/extensions": "^3.2.1",
     "@gltf-transform/functions": "^3.2.1",
-    "3d-tiles-tools": "0.4.2",
+    "3d-tiles-tools": "0.4.4",
     "cesium": "^1.97.0",
     "gltf-validator": "^2.0.0-dev.3.9",
     "minimatch": "^5.1.0",


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles-validator/issues/323

This updates the 3D Tiles tools depedency to 0.4.4, which includes https://github.com/CesiumGS/3d-tiles-tools/pull/160 that fixes the underlying issue here.

