### PR TITLE
Fix transformed bounding box computation

### DIFF
--- a/specs/TilesetValidationSpec.ts
+++ b/specs/TilesetValidationSpec.ts
@@ -417,6 +417,13 @@ describe("Tileset validation", function () {
     expect(result.get(0).type).toEqual("BOUNDING_VOLUMES_INCONSISTENT");
   });
 
+  it("detects no issues in tileContentBoundingVolumeWithRotationTransform", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/tilesets/tileContentBoundingVolumeWithRotationTransform.json"
+    );
+    expect(result.length).toEqual(0);
+  });
+
   it("detects no issues in tileContentBoundingVolumeWithTransform", async function () {
     const result = await Validators.validateTilesetFile(
       "specs/data/tilesets/tileContentBoundingVolumeWithTransform.json"

--- a/specs/data/tilesets/tileContentBoundingVolumeWithRotationTransform.json
+++ b/specs/data/tilesets/tileContentBoundingVolumeWithRotationTransform.json
@@ -1,0 +1,25 @@
+{
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 10.0 ]
+    },
+    "geometricError" : 1.0,
+    "transform": [
+      1,  0, 0, 0,
+      0,  0, 1, 0,
+      0, -1, 0, 0,
+      0,  0, 0, 1
+    ],
+    "content": {
+      "uri": "tiles/glTF/Triangle/Triangle.gltf",
+      "boundingVolume": {
+        "box" : [ 0.0, 0.0, 2.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 2.0 ]
+      }
+    }
+  }
+}

--- a/src/validation/legacy/BoundingVolumeChecks.ts
+++ b/src/validation/legacy/BoundingVolumeChecks.ts
@@ -179,13 +179,13 @@ export class BoundingVolumeChecks {
       center.y,
       center.z,
       halfAxes[0],
-      halfAxes[3],
-      halfAxes[6],
       halfAxes[1],
-      halfAxes[4],
-      halfAxes[7],
       halfAxes[2],
+      halfAxes[3],
+      halfAxes[4],
       halfAxes[5],
+      halfAxes[6],
+      halfAxes[7],
       halfAxes[8],
     ];
     return returnBox;


### PR DESCRIPTION
Fixes the second incarnation of https://github.com/CesiumGS/3d-tiles-validator/issues/321 : For some reason, the [`getTransformedBox`](https://github.com/CesiumGS/3d-tiles-validator/blob/main/src/validation/legacy/BoundingVolumeChecks.ts#L176) function (a leftover from [the legacy implementation](https://github.com/CesiumGS/3d-tiles-validator/blob/450074d8320ad585be53f0f9e58fbf0f60d2621c/validator/lib/validateTileset.js#L261)) swizzled the axis entries for the resulting box.

I'll try to create sensible specs for that. (I could just use the data from the issue, but would like to have something that is easier to visualize...)
