### PR TITLE
Update tools to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ npx 3d-tiles-validator --optionsFile exampleOptions.json
 The options represent the properties of the `ValidationOptions` class. For example, using the following `exampleOptions.json` file, then the validator will only validate the tileset JSON structure, but _no_ tile content data:
 ```JSON
 {
-  "validateContentData": false,
+  "validateContentData": false
 }
 ```
 The following options will cause the validator to _include_ B3DM- and GLB files in the validation process, but ignore all other content types:

--- a/specs/extensions/MaxarContentGeojonValidationSpec.ts
+++ b/specs/extensions/MaxarContentGeojonValidationSpec.ts
@@ -5,11 +5,11 @@ describe("Tileset MAXAR_content_geojson extension validation", function () {
     const result = await Validators.validateTilesetFile(
       "specs/data/extensions/maxarContentGeojson/validTilesetWithGeojson.json"
     );
-    // Expect one warning for skipping the GeoJSON validation
+    // Expect one info for skipping the GeoJSON validation
     // and one for the missing declaration of the
     // MAXAR_content_geojson usage in the extensionsUsed
     expect(result.length).toEqual(2);
-    expect(result.get(0).type).toEqual("CONTENT_VALIDATION_WARNING");
+    expect(result.get(0).type).toEqual("CONTENT_VALIDATION_INFO");
     expect(result.get(1).type).toEqual("EXTENSION_FOUND_BUT_NOT_USED");
   });
 
@@ -17,8 +17,8 @@ describe("Tileset MAXAR_content_geojson extension validation", function () {
     const result = await Validators.validateTilesetFile(
       "specs/data/extensions/maxarContentGeojson/validTilesetWithMaxarContentGeojson.json"
     );
-    // Expect one warning for skipping the GeoJSON validation
+    // Expect one info for skipping the GeoJSON validation
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("CONTENT_VALIDATION_WARNING");
+    expect(result.get(0).type).toEqual("CONTENT_VALIDATION_INFO");
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,7 +116,7 @@ async function main() {
   if (argv.optionsFile) {
     config.options = await readOptionsFile(argv.optionsFile);
   }
-  ValidatorMain.performValidation(args, config);
+  await ValidatorMain.performValidation(args, config);
 }
 
-main();
+void main();

--- a/src/validation/ContentDataValidators.ts
+++ b/src/validation/ContentDataValidators.ts
@@ -82,7 +82,7 @@ export class ContentDataValidators {
 
     // Certain content types are known to be encountered,
     // but are not (yet) validated. These can either be
-    // ignored, or cause a warning. In the future, this
+    // ignored, or cause an info. In the future, this
     // should be configurable, probably even on a per-type
     // basis, via the command line or a config file
     const ignoreUnhandledContentTypes = false;
@@ -90,13 +90,13 @@ export class ContentDataValidators {
     let vctrValidator = Validators.createEmptyValidator();
     let geojsonValidator = Validators.createEmptyValidator();
     if (!ignoreUnhandledContentTypes) {
-      geomValidator = Validators.createContentValidationWarning(
+      geomValidator = Validators.createContentValidationInfo(
         "Skipping 'geom' validation"
       );
-      vctrValidator = Validators.createContentValidationWarning(
+      vctrValidator = Validators.createContentValidationInfo(
         "Skipping 'vctr' validation"
       );
-      geojsonValidator = Validators.createContentValidationWarning(
+      geojsonValidator = Validators.createContentValidationInfo(
         "Skipping 'geojson' validation"
       );
     }

--- a/src/validation/TilesetPackageValidator.ts
+++ b/src/validation/TilesetPackageValidator.ts
@@ -150,14 +150,14 @@ export class TilesetPackageValidator implements Validator<string> {
       context.addIssue(issue);
       return true;
     }
-    tilesetSource.open(uri);
+    await tilesetSource.open(uri);
     const result = await TilesetPackageValidator.validatePackageInternal(
       uri,
       tilesetSource,
       isContent,
       context
     );
-    tilesetSource.close();
+    await tilesetSource.close();
     return result;
   }
 

--- a/src/validation/Validators.ts
+++ b/src/validation/Validators.ts
@@ -393,18 +393,18 @@ export class Validators {
   }
 
   /**
-   * Creates a `Validator` that only adds a `CONTENT_VALIDATION_WARNING`
+   * Creates a `Validator` that only adds a `CONTENT_VALIDATION_INFO`
    * with the given message to the given context when it is called.
    *
    * This is used for "dummy" validators that handle content data types
    * that are already anticipated (like VCTR or GEOM), but not validated
    * explicitly.
    *
-   * @param message - The message for the warning
+   * @param message - The message for the info
    * @returns The new validator
    * @internal
    */
-  static createContentValidationWarning(message: string): Validator<Buffer> {
+  static createContentValidationInfo(message: string): Validator<Buffer> {
     return {
       async validateObject(
         inputPath: string,
@@ -412,7 +412,7 @@ export class Validators {
         input: Buffer,
         context: ValidationContext
       ): Promise<boolean> {
-        const issue = ContentValidationIssues.CONTENT_VALIDATION_WARNING(
+        const issue = ContentValidationIssues.CONTENT_VALIDATION_INFO(
           inputPath,
           message
         );


### PR DESCRIPTION
(Builds on https://github.com/CesiumGS/3d-tiles-validator/pull/331 )

This updates the 3D Tiles Tools for the upcoming 0.5.0 release.

The main change for the (breaking) change to use the `async` API was pretty trivial - it just needed an `await` in a few places.

A minor change resulted from [this commit](https://github.com/CesiumGS/3d-tiles-tools/commit/5afdeab6a8435ed28149aee25bdbb1aa65b76cc2): Previously, the `TraversedTile` returned a 'subtree URI' for _both_ the _explicit_ tile that defined the implicit tiling, _and_ for the implicit root tile. Now, it only returns it for the implicit root tile. This should _usually_ not affect clients. But the validator is a different beast: It has to _explcitly_ access the `.subtree` file to perform an eager validation before even _starting_ the traversal.

A small change (that belongs to https://github.com/CesiumGS/3d-tiles-tools/commit/5afdeab6a8435ed28149aee25bdbb1aa65b76cc2 ) is: Previously, content types that are "known but not validated" (like `VCTR`, `GEOM`, and `GEOJSON`) caused a **WARNING** saying "Skipping _type_ validation". Now, this only is an **INFO**. The reasoning behind that is that the user can not do anything to "fix" this, so a **WARNING** does not seem warranted.

