### PR TITLE
Prepare release 0.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 
-Version 0.6.0 - yyyy-mm-dd
+Version 0.6.0 - 2025-02-24
 
 - Fixed a bug where a `BOUNDING_VOLUMES_INCONSISTENT` error was reported when a tile defined a `transform` [#328](https://github.com/CesiumGS/3d-tiles-validator/pull/328)
 - Allow users to provide schema files for validating custom metadata semantics [#329](https://github.com/CesiumGS/3d-tiles-validator/pull/329)
@@ -10,7 +10,7 @@ Version 0.6.0 - yyyy-mm-dd
 - Updated `3d-tiles-tools` version to `0.5.0`
   - Minor updates for the new `async` API that was introduced via [`3d-tiles-tools/pull/167`](https://github.com/CesiumGS/3d-tiles-tools/pull/167)
   - Includes a bugfix from [`3d-tiles-tools/pull/173](https://github.com/CesiumGS/3d-tiles-tools/pull/173) where 3TZ files that contained certain local ZIP file headers caused an internal error in the validator
-
+- Changed the severity of issues that have been generated for content types that are known but not validated (like `VCTR`, `GEOM`, and `GEOJSON`) from `WARNING` to `INFO` [#332](https://github.com/CesiumGS/3d-tiles-validator/pull/332)
 
 Version 0.5.1 - 2024-12-05
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,16 @@
 
-Version ?.?.? - yyyy-mm-dd
+Version 0.6.0 - yyyy-mm-dd
 
-- ...
+- Fixed a bug where a `BOUNDING_VOLUMES_INCONSISTENT` error was reported when a tile defined a `transform` [#328](https://github.com/CesiumGS/3d-tiles-validator/pull/328)
+- Allow users to provide schema files for validating custom metadata semantics [#329](https://github.com/CesiumGS/3d-tiles-validator/pull/329)
+- Do not emit warnings when encountering `MAXAR_content_geojson`, `VRICON_class`, or `VRICON_grid` extensions [#330](https://github.com/CesiumGS/3d-tiles-validator/pull/330)
+- Fixes for 3TZ validation [#331](https://github.com/CesiumGS/3d-tiles-validator/pull/331)
+  - Fixed a bug where a 3TZ file could not be referred to with a relative path
+  - Handled the case where completely invalid 3TZ files caused an `INTERNAL_ERROR`
+- Updated `3d-tiles-tools` version to `0.5.0`
+  - Minor updates for the new `async` API that was introduced via [`3d-tiles-tools/pull/167`](https://github.com/CesiumGS/3d-tiles-tools/pull/167)
+  - Includes a bugfix from [`3d-tiles-tools/pull/173](https://github.com/CesiumGS/3d-tiles-tools/pull/173) where 3TZ files that contained certain local ZIP file headers caused an internal error in the validator
+
 
 Version 0.5.1 - 2024-12-05
 

--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -4,7 +4,7 @@
     "license": [
       "Apache-2.0"
     ],
-    "version": "0.4.4",
+    "version": "0.5.0",
     "url": "https://www.npmjs.com/package/3d-tiles-tools"
   },
   {

--- a/etc/3d-tiles-validator.api.md
+++ b/etc/3d-tiles-validator.api.md
@@ -56,6 +56,8 @@ export class ValidationOptions {
     static fromJson(json: any): ValidationOptions;
     get includeContentTypes(): string[] | undefined;
     set includeContentTypes(value: string[] | undefined);
+    get semanticSchemaFileNames(): string[] | undefined;
+    set semanticSchemaFileNames(value: string[] | undefined);
     get validateContentData(): boolean;
     set validateContentData(value: boolean);
 }
@@ -86,7 +88,7 @@ export class ValidationResult {
 // @beta
 export class Validators {
     // @internal
-    static createContentValidationWarning(message: string): Validator<Buffer>;
+    static createContentValidationInfo(message: string): Validator<Buffer>;
     // Warning: (ae-forgotten-export) The symbol "SchemaValidator" needs to be exported by the entry point index.d.ts
     //
     // @internal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3d-tiles-validator",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "description": "Tools for validating 3D Tiles tilesets.",
   "keywords": [


### PR DESCRIPTION
Builds upon https://github.com/CesiumGS/3d-tiles-validator/pull/332

- Updated version number in package.json to 0.6.0
- Updated ThirdParty and API definition files
- Updated CHANGES.md
- Added a section about custom metadata semantics in the README, as implemented in https://github.com/CesiumGS/3d-tiles-validator/pull/329. Here is a [direct preview of that new section](https://github.com/CesiumGS/3d-tiles-validator/blob/af66ef78eb485a04996fcf913b7f94a46cb03cf1/README.md#custom-metadata-semantics)

(This is a 'draft' only because the release date has to be filled in...)

