### PR TITLE
Validation for `3DTILES_content_gltf`

### DIFF
--- a/specs/data/extensions/contentGltf/contentGltfExtensionRequiredButNotUsed.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionRequiredButNotUsed.json
@@ -1,0 +1,24 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsRequired": [
+        "KHR_materials_unlit"
+      ]
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/contentGltfExtensionsRequiredDuplicateElement.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionsRequiredDuplicateElement.json
@@ -1,0 +1,28 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsUsed": [
+        "KHR_materials_unlit"
+      ],
+      "extensionsRequired": [
+        "KHR_materials_unlit",
+        "KHR_materials_unlit"
+      ]
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidArrayLength.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidArrayLength.json
@@ -1,0 +1,22 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsRequired": []
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidElementType.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidElementType.json
@@ -1,0 +1,28 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsUsed": [
+        "KHR_materials_unlit"
+      ],
+      "extensionsRequired": [
+        "KHR_materials_unlit",
+        1234
+      ]
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidType.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidType.json
@@ -1,0 +1,22 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsRequired": "NOT_AN_ARRAY"
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/contentGltfExtensionsUsedDuplicateElement.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionsUsedDuplicateElement.json
@@ -1,0 +1,25 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsUsed": [
+        "KHR_materials_unlit",
+        "KHR_materials_unlit"
+      ]
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidArrayLength.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidArrayLength.json
@@ -1,0 +1,22 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsUsed": []
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidElementType.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidElementType.json
@@ -1,0 +1,25 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsUsed": [
+        "KHR_materials_unlit",
+        1234
+      ]
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidType.json
+++ b/specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidType.json
@@ -1,0 +1,22 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsUsed": "NOT_AN_ARRAY"
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/tileset_1_0_withContentGltfRequiredButNotUsed.json
+++ b/specs/data/extensions/contentGltf/tileset_1_0_withContentGltfRequiredButNotUsed.json
@@ -1,0 +1,17 @@
+{
+  "extensionsRequired": ["3DTILES_content_gltf"],
+  "asset" : {
+    "version" : "1.0"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/tileset_1_0_withContentGltfUsedButNotFound.json
+++ b/specs/data/extensions/contentGltf/tileset_1_0_withContentGltfUsedButNotFound.json
@@ -1,0 +1,18 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensionsRequired": ["3DTILES_content_gltf"],
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/b3dm/valid.b3dm"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/tileset_1_0_withContentGltfUsedButNotRequired.json
+++ b/specs/data/extensions/contentGltf/tileset_1_0_withContentGltfUsedButNotRequired.json
@@ -1,0 +1,17 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "asset" : {
+    "version" : "1.0"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/tileset_1_1_withContentGltfUsedButNotFound.json
+++ b/specs/data/extensions/contentGltf/tileset_1_1_withContentGltfUsedButNotFound.json
@@ -1,0 +1,17 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/validTileset_1_0_withGltf.json
+++ b/specs/data/extensions/contentGltf/validTileset_1_0_withGltf.json
@@ -1,0 +1,18 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensionsRequired": ["3DTILES_content_gltf"],
+  "asset" : {
+    "version" : "1.0"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/validTileset_1_1_withContentGltfUsedAndFound.json
+++ b/specs/data/extensions/contentGltf/validTileset_1_1_withContentGltfUsedAndFound.json
@@ -1,0 +1,24 @@
+{
+  "extensionsUsed": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_content_gltf": {
+      "extensionsUsed": [
+        "KHR_materials_unlit"
+      ]
+    }
+  },  
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/data/extensions/contentGltf/validTileset_1_1_withGltf.json
+++ b/specs/data/extensions/contentGltf/validTileset_1_1_withGltf.json
@@ -1,0 +1,16 @@
+{
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "../../tilesets/tiles/glTF/Triangle/Triangle.gltf"
+    }
+  }
+}

--- a/specs/extensions/ContentGltfValidationSpec.ts
+++ b/specs/extensions/ContentGltfValidationSpec.ts
@@ -1,0 +1,128 @@
+import { Validators } from "../../src/validation/Validators";
+
+describe("Tileset 3DTILES_content_gltf extension validation", function () {
+  it("detects issues in contentGltfExtensionRequiredButNotUsed", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionRequiredButNotUsed.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("EXTENSION_REQUIRED_BUT_NOT_USED");
+  });
+
+  it("detects issues in contentGltfExtensionsRequiredDuplicateElement", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionsRequiredDuplicateElement.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_ELEMENT_NOT_UNIQUE");
+  });
+
+  it("detects issues in contentGltfExtensionsRequiredInvalidArrayLength", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidArrayLength.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_LENGTH_MISMATCH");
+  });
+
+  it("detects issues in contentGltfExtensionsRequiredInvalidElementType", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidElementType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_ELEMENT_TYPE_MISMATCH");
+  });
+
+  it("detects issues in contentGltfExtensionsRequiredInvalidType", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionsRequiredInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in contentGltfExtensionsUsedDuplicateElement", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionsUsedDuplicateElement.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_ELEMENT_NOT_UNIQUE");
+  });
+
+  it("detects issues in contentGltfExtensionsUsedInvalidArrayLength", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidArrayLength.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_LENGTH_MISMATCH");
+  });
+
+  it("detects issues in contentGltfExtensionsUsedInvalidElementType", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidElementType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("ARRAY_ELEMENT_TYPE_MISMATCH");
+  });
+
+  it("detects issues in contentGltfExtensionsUsedInvalidType", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/contentGltfExtensionsUsedInvalidType.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in tileset_1_0_withContentGltfRequiredButNotUsed", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/tileset_1_0_withContentGltfRequiredButNotUsed.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("EXTENSION_REQUIRED_BUT_NOT_USED");
+  });
+
+  it("detects issues in tileset_1_0_withContentGltfUsedButNotFound", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/tileset_1_0_withContentGltfUsedButNotFound.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("EXTENSION_USED_BUT_NOT_FOUND");
+  });
+
+  it("detects issues in tileset_1_0_withContentGltfUsedButNotRequired", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/tileset_1_0_withContentGltfUsedButNotRequired.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("EXTENSION_REQUIRED_BUT_NOT_DECLARED");
+  });
+
+  it("detects issues in tileset_1_1_withContentGltfUsedButNotFound", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/tileset_1_1_withContentGltfUsedButNotFound.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("EXTENSION_USED_BUT_NOT_FOUND");
+  });
+
+  it("detects no issues in validTileset_1_0_withGltf", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/validTileset_1_0_withGltf.json"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("detects no issues in validTileset_1_1_withContentGltfUsedAndFound", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/validTileset_1_1_withContentGltfUsedAndFound.json"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("detects no issues in validTileset_1_1_withGltf", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/extensions/contentGltf/validTileset_1_1_withGltf.json"
+    );
+    expect(result.length).toEqual(0);
+  });
+});

--- a/src/issues/SemanticValidationIssues.ts
+++ b/src/issues/SemanticValidationIssues.ts
@@ -337,6 +337,28 @@ export class SemanticValidationIssues {
   }
 
   /**
+   * Indicates that a certain extension would be required
+   * to be listed in the `extensionsRequired`, but was not
+   * declared there.
+   *
+   * @param path - The path for the `ValidationIssue`
+   * @param extensionName - The extension name
+   * @returns The `ValidationIssue`
+   */
+  static EXTENSION_REQUIRED_BUT_NOT_DECLARED(
+    path: string,
+    extensionName: string
+  ) {
+    const type = "EXTENSION_REQUIRED_BUT_NOT_DECLARED";
+    const severity = ValidationIssueSeverity.ERROR;
+    const message =
+      `The extension '${extensionName}' is required, but ` +
+      `was not declared in 'extensionsRequired'`;
+    const issue = new ValidationIssue(type, path, message, severity);
+    return issue;
+  }
+
+  /**
    * Indicates that a certain extension was found, but was not
    * listed in the 'extensionsUsed' of a tileset.
    *

--- a/src/validation/ExtensionsDeclarationsValidator.ts
+++ b/src/validation/ExtensionsDeclarationsValidator.ts
@@ -1,0 +1,125 @@
+import { defined } from "3d-tiles-tools";
+
+import { ValidationContext } from "./ValidationContext";
+import { BasicValidator } from "./BasicValidator";
+
+import { SemanticValidationIssues } from "../issues/SemanticValidationIssues";
+
+/**
+ * A class for validating extension declarations that may appear
+ * as `extensionsUsed` and `extensionsRequired` arrays in a
+ * tileset or the `3DTILES_content_gltf` extension.
+ *
+ * @internal
+ */
+export class ExtensionsDeclarationsValidator {
+  /**
+   * Validate the consistency of the given extension declarations.
+   *
+   * This will check whether the given `extensionsUsed` and
+   * `extensionRequired` declarations are consistent:
+   *
+   * - If the objects are defined, they are string arrays with
+   *   at least length 1
+   * - The elements in these arrays are unique
+   * - Extensions that are "required" are also "used"
+   *
+   * @param path - The path for `ValidationIssue` instances
+   * @param tileset - The `Tileset`
+   * @param context - The `ValidationContext`
+   * @returns Whether the declarations have been valid
+   */
+  static validateExtensionDeclarationConsistency(
+    path: string,
+    extensionsUsed: any,
+    extensionsRequired: any,
+    context: ValidationContext
+  ): boolean {
+    let result = true;
+
+    // These are the actual sets of unique string values that
+    // are found in 'extensionsUsed' and 'extensionsRequired'
+    const actualExtensionsUsed = new Set<string>();
+    const actualExtensionsRequired = new Set<string>();
+
+    // Validate the extensionsUsed
+    const extensionsUsedPath = path + "/extensionsUsed";
+    if (defined(extensionsUsed)) {
+      // The extensionsUsed MUST be an array of strings with
+      // a length of at least 1
+      if (
+        !BasicValidator.validateArray(
+          extensionsUsedPath,
+          "extensionsUsed",
+          extensionsUsed,
+          1,
+          undefined,
+          "string",
+          context
+        )
+      ) {
+        result = false;
+      } else {
+        extensionsUsed.forEach((e: any) => actualExtensionsUsed.add(e));
+
+        // The elements in extensionsUsed MUST be unique
+        const elementsUnique = BasicValidator.validateArrayElementsUnique(
+          extensionsUsedPath,
+          "extensionsUsed",
+          extensionsUsed,
+          context
+        );
+        if (!elementsUnique) {
+          result = false;
+        }
+      }
+    }
+
+    // Validate the extensionsRequired
+    const extensionsRequiredPath = path + "/extensionsRequired";
+    if (defined(extensionsRequired)) {
+      // The extensionsRequired MUST be an array of strings with
+      // a length of at least 1
+      if (
+        !BasicValidator.validateArray(
+          extensionsRequiredPath,
+          "extensionsRequired",
+          extensionsRequired,
+          1,
+          undefined,
+          "string",
+          context
+        )
+      ) {
+        result = false;
+      } else {
+        extensionsRequired.forEach((e: any) => actualExtensionsRequired.add(e));
+
+        // The elements in extensionsRequired MUST be unique
+        const elementsUnique = BasicValidator.validateArrayElementsUnique(
+          extensionsRequiredPath,
+          "extensionsRequired",
+          extensionsRequired,
+          context
+        );
+        if (!elementsUnique) {
+          result = false;
+        }
+      }
+    }
+
+    // Each extension in extensionsRequired MUST also
+    // appear in extensionsUsed.
+    for (const extensionName of actualExtensionsRequired) {
+      if (!actualExtensionsUsed.has(extensionName)) {
+        const issue = SemanticValidationIssues.EXTENSION_REQUIRED_BUT_NOT_USED(
+          extensionsUsedPath,
+          extensionName
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+    }
+    return result;
+  }
+}

--- a/src/validation/Validators.ts
+++ b/src/validation/Validators.ts
@@ -17,6 +17,7 @@ import { ExtendedObjectsValidators } from "./ExtendedObjectsValidators";
 import { TilesetPackageValidator } from "./TilesetPackageValidator";
 import { ContentDataValidators } from "./ContentDataValidators";
 import { ValidatedElement } from "./ValidatedElement";
+import { ValidationContexts } from "./ValidationContexts";
 
 import { SchemaValidator } from "./metadata/SchemaValidator";
 
@@ -25,7 +26,7 @@ import { ContentValidationIssues } from "../issues/ContentValidationIssues";
 
 import { BoundingVolumeS2Validator } from "./extensions/BoundingVolumeS2Validator";
 import { NgaGpmValidator } from "./extensions/NgaGpmValidator";
-import { ValidationContexts } from "./ValidationContexts";
+import { ContentGltfValidator } from "./extensions/ContentGltfValidator";
 
 /**
  * Utility methods related to `Validator` instances.
@@ -465,15 +466,13 @@ export class Validators {
       );
     }
 
-    // Register an empty validator for 3DTILES_content_gltf
-    // (The extension does not have any properties to be
-    // validated)
+    // Register the validator for 3DTILES_content_gltf
     {
-      const emptyValidator = Validators.createEmptyValidator();
+      const contentGltfValidator = new ContentGltfValidator();
       const override = false;
       ExtendedObjectsValidators.register(
         "3DTILES_content_gltf",
-        emptyValidator,
+        contentGltfValidator,
         override
       );
     }

--- a/src/validation/extensions/ContentGltfValidator.ts
+++ b/src/validation/extensions/ContentGltfValidator.ts
@@ -1,0 +1,84 @@
+import { defined } from "3d-tiles-tools";
+
+import { Validator } from "../Validator";
+import { ValidationContext } from "../ValidationContext";
+import { BasicValidator } from "../BasicValidator";
+import { ExtensionsDeclarationsValidator } from "../ExtensionsDeclarationsValidator";
+
+/**
+ * A class for the validation of `3DTILES_content_gltf` extension objects
+ *
+ * @internal
+ */
+export class ContentGltfValidator implements Validator<any> {
+  /**
+   * Performs the validation of a `Tileset` object that
+   * contains a `3DTILES_content_gltf` extension object.
+   *
+   * @param path - The path for `ValidationIssue` instances
+   * @param boundingVolume - The object to validate
+   * @param context - The `ValidationContext` that any issues will be added to
+   * @returns Whether the object was valid
+   */
+  async validateObject(
+    path: string,
+    tileset: any,
+    context: ValidationContext
+  ): Promise<boolean> {
+    // Make sure that the given value is an object
+    if (!BasicValidator.validateObject(path, "tileset", tileset, context)) {
+      return false;
+    }
+
+    let result = true;
+
+    // If there is a 3DTILES_content_gltf extension,
+    // perform the validation of the corresponding object
+    const extensions = tileset.extensions;
+    if (defined(extensions)) {
+      const key = "3DTILES_content_gltf";
+      const extension = extensions[key];
+      const extensionPath = path + "/" + key;
+      if (
+        !ContentGltfValidator.validateContentGltf(
+          extensionPath,
+          extension,
+          context
+        )
+      ) {
+        result = false;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Performs the validation to ensure that the given object is a
+   * valid `3DTILES_content_gltf` object.
+   *
+   * @param path - The path for `ValidationIssue` instances
+   * @param object - The object to validate
+   * @param context - The `ValidationContext` that any issues will be added to
+   * @returns Whether the object was valid
+   */
+  static validateContentGltf(
+    path: string,
+    object: any,
+    context: ValidationContext
+  ): boolean {
+    // Make sure that the given value is an object
+    if (!BasicValidator.validateObject(path, "object", object, context)) {
+      return false;
+    }
+
+    const extensionsUsed = object.extensionsUsed;
+    const extensionsRequired = object.extensionsRequired;
+    return ExtensionsDeclarationsValidator.validateExtensionDeclarationConsistency(
+      path,
+      extensionsUsed,
+      extensionsRequired,
+      context
+    );
+  }
+}


### PR DESCRIPTION
Supposed to be merged _after_ https://github.com/CesiumGS/3d-tiles/pull/810

Fixes https://github.com/CesiumGS/3d-tiles-validator/issues/335

The `3DTILES_content_gltf` extension is about to be un-deprecated via https://github.com/CesiumGS/3d-tiles/pull/810 . This means that it may now appear in 3D Tiles 1.1 data. There are some differences in terms of whether the extension is "used", "required", or "found" between 1.0 and 1.1. This is implemented in the [`TilesetValidator`](https://github.com/CesiumGS/3d-tiles-validator/blob/8484909a44fe35cabe9ce2881fd98d5092e3cef3/src/validation/TilesetValidator.ts#L340) as follows:

- For 1.0: 
  - When glTF content is encountered, then it must be declared in `extensionsUsed`
  - When the extension is in `extensionsUsed`, then it must also be in `extensionsRequired`
  - When the extension is in `extensionsUsed`, and no glTF content is encountered (and no extension object) then a warning will be emitted
- For 1.1:
  - Just encountering glTF content does **not** mean that it has to be in `extensionsUsed`!
  - Only when an actual `tileset.extensions["3DTILES_content_gltf"]` object is found, then it must be declared in in `extensionsUsed`
  - When it is declared as `extensionUsed`, but no extension object is found, then a warning will be emitted
  - (The extension is never _required_ in 1.1)

The actual `3DTILES_content_gltf { extensionsUsed ..., extensionsRequired }` objects are now undergoing the same consistency checks that have already been done for the _tileset_-level `extensionsUsed/Required` arrays. This functionality has been moved into a utility class and just called from the tileset validator and the new `ContentGltfValidator`. It checks whether the arrays have proper type, size, element types, unique elements, and whether the "required implies used" rule holds.

