### PR TITLE
Fix issue type for string length mismatch

### DIFF
--- a/specs/BinaryBufferStructureSpec.ts
+++ b/specs/BinaryBufferStructureSpec.ts
@@ -123,7 +123,7 @@ describe("3d-tiles-tools", function () {
     performTestValidation(binaryBufferStructure, context);
     const result = context.getResult();
     expect(result.length).toEqual(1);
-    expect(result.get(0).type).toEqual("ARRAY_LENGTH_MISMATCH");
+    expect(result.get(0).type).toEqual("STRING_LENGTH_MISMATCH");
   });
 
   it("detects issues in buffersElementNameInvalidType", async function () {

--- a/src/validation/BasicValidator.ts
+++ b/src/validation/BasicValidator.ts
@@ -773,7 +773,7 @@ export class BasicValidator {
       const message =
         `String '${name}' must have a length of ${rangeDescription}, ` +
         `but the actual length is ${value.length}`;
-      const issue = JsonValidationIssues.ARRAY_LENGTH_MISMATCH(path, message);
+      const issue = JsonValidationIssues.STRING_LENGTH_MISMATCH(path, message);
       context.addIssue(issue);
       return false;
     }


### PR DESCRIPTION
There can be `minLength/maxLength` properties in a JSON schema, constraining the lengths of strings. There is a function for validating these, namely `BasicValidator.validateStringLength`. Until now, this erroneously reported wrong lengths as `ARRAY_LENGTH_MISMATCH`, even though it should have been `STRING_LENGTH_MISMATCH`. This is fixed here.

