### PR TITLE
Add MAXAR_temporal_light_traits glTF extension validator

### DIFF
--- a/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidDutyWithSineWaveform.gltf
+++ b/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidDutyWithSineWaveform.gltf
@@ -1,0 +1,45 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "extensionsUsed": [
+    "KHR_lights_punctual",
+    "MAXAR_temporal_light_traits"
+  ],
+  "extensions": {
+    "KHR_lights_punctual": {
+      "lights": [
+        {
+          "type": "point",
+          "color": [1.0, 0.0, 0.0],
+          "intensity": 20.0,
+          "name": "Invalid Duty with Sine Light",
+          "extensions": {
+            "MAXAR_temporal_light_traits": {
+              "flashing": {
+                "waveform": "sine",
+                "frequency": 2.0,
+                "duty": 0.75
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "invalid_duty_sine_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 0
+        }
+      }
+    }
+  ]
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidDutyWithTriangleWaveform.gltf
+++ b/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidDutyWithTriangleWaveform.gltf
@@ -1,0 +1,45 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "extensionsUsed": [
+    "KHR_lights_punctual",
+    "MAXAR_temporal_light_traits"
+  ],
+  "extensions": {
+    "KHR_lights_punctual": {
+      "lights": [
+        {
+          "type": "point",
+          "color": [1.0, 0.0, 0.0],
+          "intensity": 20.0,
+          "name": "Invalid Duty with Triangle Light",
+          "extensions": {
+            "MAXAR_temporal_light_traits": {
+              "flashing": {
+                "waveform": "triangle",
+                "frequency": 2.0,
+                "duty": 0.3
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "invalid_duty_triangle_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 0
+        }
+      }
+    }
+  ]
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidMissingWaveform.gltf
+++ b/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidMissingWaveform.gltf
@@ -1,0 +1,43 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "extensionsUsed": [
+    "KHR_lights_punctual",
+    "MAXAR_temporal_light_traits"
+  ],
+  "extensions": {
+    "KHR_lights_punctual": {
+      "lights": [
+        {
+          "type": "point",
+          "color": [1.0, 0.0, 0.0],
+          "intensity": 20.0,
+          "name": "Invalid Flashing Light",
+          "extensions": {
+            "MAXAR_temporal_light_traits": {
+              "flashing": {
+                "frequency": 2.0
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "invalid_flashing_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 0
+        }
+      }
+    }
+  ]
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidUndeclaredExtension.gltf
+++ b/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidUndeclaredExtension.gltf
@@ -1,0 +1,43 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "extensionsUsed": [
+    "KHR_lights_punctual"
+  ],
+  "extensions": {
+    "KHR_lights_punctual": {
+      "lights": [
+        {
+          "type": "point",
+          "color": [1.0, 0.0, 0.0],
+          "intensity": 20.0,
+          "name": "Undeclared Extension Light",
+          "extensions": {
+            "MAXAR_temporal_light_traits": {
+              "flashing": {
+                "waveform": "square",
+                "frequency": 2.0
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "undeclared_extension_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 0
+        }
+      }
+    }
+  ]
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidWaveform.gltf
+++ b/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidWaveform.gltf
@@ -1,0 +1,44 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "extensionsUsed": [
+    "KHR_lights_punctual",
+    "MAXAR_temporal_light_traits"
+  ],
+  "extensions": {
+    "KHR_lights_punctual": {
+      "lights": [
+        {
+          "type": "point",
+          "color": [1.0, 0.0, 0.0],
+          "intensity": 20.0,
+          "name": "Invalid Waveform Light",
+          "extensions": {
+            "MAXAR_temporal_light_traits": {
+              "flashing": {
+                "waveform": "invalid_waveform",
+                "frequency": 2.0
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "invalid_waveform_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 0
+        }
+      }
+    }
+  ]
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/validDutyWithSquareWaveform.gltf
+++ b/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/validDutyWithSquareWaveform.gltf
@@ -1,0 +1,45 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "extensionsUsed": [
+    "KHR_lights_punctual",
+    "MAXAR_temporal_light_traits"
+  ],
+  "extensions": {
+    "KHR_lights_punctual": {
+      "lights": [
+        {
+          "type": "point",
+          "color": [1.0, 0.0, 0.0],
+          "intensity": 20.0,
+          "name": "Valid Duty with Square Light",
+          "extensions": {
+            "MAXAR_temporal_light_traits": {
+              "flashing": {
+                "waveform": "square",
+                "frequency": 2.0,
+                "duty": 0.8
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "valid_duty_square_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 0
+        }
+      }
+    }
+  ]
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/validTemporalLightTraits.gltf
+++ b/specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/validTemporalLightTraits.gltf
@@ -1,0 +1,91 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "extensionsUsed": [
+    "KHR_lights_punctual",
+    "MAXAR_temporal_light_traits"
+  ],
+  "extensions": {
+    "KHR_lights_punctual": {
+      "lights": [
+        {
+          "type": "directional",
+          "color": [1.0, 0.9, 0.7],
+          "intensity": 3.0,
+          "name": "Directional Light"
+        },
+        {
+          "type": "point",
+          "color": [1.0, 0.0, 0.0],
+          "intensity": 20.0,
+          "range": 100.0,
+          "name": "Flashing Point Light",
+          "extensions": {
+            "MAXAR_temporal_light_traits": {
+              "flashing": {
+                "waveform": "square",
+                "frequency": 2.0,
+                "duty": 0.75,
+                "amplitudeOffset": 0.1,
+                "amplitudeScale": 0.8,
+                "phaseOffset": 0.5
+              }
+            }
+          }
+        },
+        {
+          "type": "spot",
+          "color": [0.3, 0.7, 1.0],
+          "intensity": 40.0,
+          "spot": {
+            "innerConeAngle": 0.785398163397448,
+            "outerConeAngle": 1.57079632679
+          },
+          "name": "Flashing Spot Light",
+          "extensions": {
+            "MAXAR_temporal_light_traits": {
+              "flashing": {
+                "waveform": "sine",
+                "frequency": 1.5
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "scenes": [
+    {
+      "nodes": [0, 1, 2]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "directional_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 0
+        }
+      }
+    },
+    {
+      "name": "flashing_point_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 1
+        }
+      },
+      "translation": [0, 22, 0]
+    },
+    {
+      "name": "flashing_spot_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 2
+        }
+      },
+      "translation": [10, 10, 10]
+    }
+  ]
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/validKhrLightsPunctual.gltf
+++ b/specs/data/gltfExtensions/khrLightsPunctual/validKhrLightsPunctual.gltf
@@ -1,0 +1,70 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "extensionsUsed": [
+    "KHR_lights_punctual"
+  ],
+  "extensions": {
+    "KHR_lights_punctual": {
+      "lights": [
+        {
+          "type": "directional",
+          "color": [1.0, 0.9, 0.7],
+          "intensity": 3.0,
+          "name": "Directional Light"
+        },
+        {
+          "type": "point",
+          "color": [1.0, 0.0, 0.0],
+          "intensity": 20.0,
+          "range": 100.0,
+          "name": "Point Light"
+        },
+        {
+          "type": "spot",
+          "color": [0.3, 0.7, 1.0],
+          "intensity": 40.0,
+          "spot": {
+            "innerConeAngle": 0.785398163397448,
+            "outerConeAngle": 1.57079632679
+          },
+          "name": "Spot Light"
+        }
+      ]
+    }
+  },
+  "scenes": [
+    {
+      "nodes": [0, 1, 2]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "directional_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 0
+        }
+      }
+    },
+    {
+      "name": "point_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 1
+        }
+      },
+      "translation": [0, 22, 0]
+    },
+    {
+      "name": "spot_light",
+      "extensions": {
+        "KHR_lights_punctual": {
+          "light": 2
+        }
+      },
+      "translation": [10, 10, 10]
+    }
+  ]
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/validTilesetWithInvalidKhrLightsPunctual.json
+++ b/specs/data/gltfExtensions/khrLightsPunctual/validTilesetWithInvalidKhrLightsPunctual.json
@@ -1,0 +1,23 @@
+{
+  "asset": {
+    "version": "1.1"
+  },
+  "geometricError": 1000,
+  "root": {
+    "boundingVolume": {
+      "region": [
+        -1.3197004795898053,
+        0.6988582109,
+        -1.3196595204101946,
+        0.6988897891,
+        0,
+        20
+      ]
+    },
+    "geometricError": 0,
+    "refine": "REPLACE",
+    "content": {
+      "uri": "./maxarTemporalLightTraits/invalidUndeclaredExtension.gltf"
+    }
+  }
+}

--- a/specs/data/gltfExtensions/khrLightsPunctual/validTilesetWithKhrLightsPunctual.json
+++ b/specs/data/gltfExtensions/khrLightsPunctual/validTilesetWithKhrLightsPunctual.json
@@ -1,0 +1,23 @@
+{
+  "asset": {
+    "version": "1.1"
+  },
+  "geometricError": 1000,
+  "root": {
+    "boundingVolume": {
+      "region": [
+        -1.3197004795898053,
+        0.6988582109,
+        -1.3196595204101946,
+        0.6988897891,
+        0,
+        20
+      ]
+    },
+    "geometricError": 0,
+    "refine": "REPLACE",
+    "content": {
+      "uri": "validKhrLightsPunctual.gltf"
+    }
+  }
+}

--- a/specs/gltfExtensions/KhrLightsPunctualValidationSpec.ts
+++ b/specs/gltfExtensions/KhrLightsPunctualValidationSpec.ts
@@ -1,0 +1,18 @@
+import { Validators } from "../../src/validation/Validators";
+
+describe("KHR_lights_punctual extension validation", function () {
+  it("detects no issues in validTilesetWithKhrLightsPunctual when no temporal traits are used", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/gltfExtensions/khrLightsPunctual/validTilesetWithKhrLightsPunctual.json"
+    );
+    // Should only have info messages, no errors since we only validate temporal traits
+    let hasErrors = false;
+    for (let i = 0; i < result.length; i++) {
+      if (result.get(i).severity === "ERROR") {
+        hasErrors = true;
+        break;
+      }
+    }
+    expect(hasErrors).toBe(false);
+  });
+});

--- a/specs/gltfExtensions/KhrLightsPunctualValidationSpec.ts
+++ b/specs/gltfExtensions/KhrLightsPunctualValidationSpec.ts
@@ -6,13 +6,17 @@ describe("KHR_lights_punctual extension validation", function () {
       "specs/data/gltfExtensions/khrLightsPunctual/validTilesetWithKhrLightsPunctual.json"
     );
     // Should only have info messages, no errors since we only validate temporal traits
-    let hasErrors = false;
-    for (let i = 0; i < result.length; i++) {
-      if (result.get(i).severity === "ERROR") {
-        hasErrors = true;
-        break;
-      }
-    }
-    expect(hasErrors).toBe(false);
+    expect(result.length).toEqual(0);
+  });
+
+  it("detects issues in validTilesetWithInvalidKhrLightsPunctual", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/gltfExtensions/khrLightsPunctual/validTilesetWithInvalidKhrLightsPunctual.json"
+    );
+    // Expect one error from the glTF Validator that complains about
+    // the MAXAR_temporal_light_traits extension being used within
+    // one light, but not being declared in extensionsUsed.
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("CONTENT_VALIDATION_ERROR");
   });
 });

--- a/specs/gltfExtensions/MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidationSpec.ts
+++ b/specs/gltfExtensions/MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidationSpec.ts
@@ -1,0 +1,144 @@
+import { validateGltf } from "../validateGltf";
+
+describe("MAXAR_temporal_light_traits extension validation", function () {
+  it("detects no issues in validTemporalLightTraits", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/validTemporalLightTraits.gltf"
+    );
+    // Should only have info messages, no errors
+    let hasErrors = false;
+    for (let i = 0; i < result.length; i++) {
+      if (result.get(i).severity === "ERROR") {
+        hasErrors = true;
+        break;
+      }
+    }
+    expect(hasErrors).toBe(false);
+  });
+
+  it("detects missing waveform property in temporal light traits", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidMissingWaveform.gltf"
+    );
+    expect(result.length).toBeGreaterThan(0);
+
+    // Find the error about missing waveform property
+    let foundMissingWaveform = false;
+    for (let i = 0; i < result.length; i++) {
+      const issue = result.get(i);
+      if (
+        issue.type === "INVALID_GLTF_STRUCTURE" &&
+        issue.message.includes("waveform") &&
+        issue.message.includes("required")
+      ) {
+        foundMissingWaveform = true;
+        break;
+      }
+    }
+    expect(foundMissingWaveform).toBe(true);
+  });
+
+  it("detects invalid waveform value in temporal light traits", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidWaveform.gltf"
+    );
+    expect(result.length).toBeGreaterThan(0);
+
+    // Find the error about invalid waveform value
+    let foundInvalidWaveform = false;
+    for (let i = 0; i < result.length; i++) {
+      const issue = result.get(i);
+      if (
+        issue.type === "INVALID_GLTF_STRUCTURE" &&
+        issue.message.includes("waveform") &&
+        (issue.message.includes("sine") ||
+          issue.message.includes("square") ||
+          issue.message.includes("triangle"))
+      ) {
+        foundInvalidWaveform = true;
+        break;
+      }
+    }
+    expect(foundInvalidWaveform).toBe(true);
+  });
+
+  it("detects undeclared MAXAR_temporal_light_traits extension", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidUndeclaredExtension.gltf"
+    );
+    expect(result.length).toBeGreaterThan(0);
+
+    // Find the error about undeclared extension
+    let foundUndeclaredExtension = false;
+    for (let i = 0; i < result.length; i++) {
+      const issue = result.get(i);
+      if (
+        issue.type === "INVALID_GLTF_STRUCTURE" &&
+        issue.message.includes("not declared in extensionsUsed")
+      ) {
+        foundUndeclaredExtension = true;
+        break;
+      }
+    }
+    expect(foundUndeclaredExtension).toBe(true);
+  });
+
+  it("detects invalid duty property with sine waveform", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidDutyWithSineWaveform.gltf"
+    );
+    expect(result.length).toBeGreaterThan(0);
+
+    // Find the error about duty property only applicable for square waveforms
+    let foundInvalidDuty = false;
+    for (let i = 0; i < result.length; i++) {
+      const issue = result.get(i);
+      if (
+        issue.type === "INVALID_GLTF_STRUCTURE" &&
+        issue.message.includes("duty") &&
+        issue.message.includes("square")
+      ) {
+        foundInvalidDuty = true;
+        break;
+      }
+    }
+    expect(foundInvalidDuty).toBe(true);
+  });
+
+  it("detects invalid duty property with triangle waveform", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidDutyWithTriangleWaveform.gltf"
+    );
+    expect(result.length).toBeGreaterThan(0);
+
+    // Find the error about duty property only applicable for square waveforms
+    let foundInvalidDuty = false;
+    for (let i = 0; i < result.length; i++) {
+      const issue = result.get(i);
+      if (
+        issue.type === "INVALID_GLTF_STRUCTURE" &&
+        issue.message.includes("duty") &&
+        issue.message.includes("square")
+      ) {
+        foundInvalidDuty = true;
+        break;
+      }
+    }
+    expect(foundInvalidDuty).toBe(true);
+  });
+
+  it("detects no issues with valid duty property and square waveform", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/validDutyWithSquareWaveform.gltf"
+    );
+    // Should only have info messages, no errors
+    let hasErrors = false;
+    for (let i = 0; i < result.length; i++) {
+      if (result.get(i).severity === "ERROR") {
+        hasErrors = true;
+        break;
+      }
+    }
+    expect(hasErrors).toBe(false);
+  });
+});

--- a/specs/gltfExtensions/MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidationSpec.ts
+++ b/specs/gltfExtensions/MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidationSpec.ts
@@ -5,140 +5,53 @@ describe("MAXAR_temporal_light_traits extension validation", function () {
     const result = await validateGltf(
       "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/validTemporalLightTraits.gltf"
     );
-    // Should only have info messages, no errors
-    let hasErrors = false;
-    for (let i = 0; i < result.length; i++) {
-      if (result.get(i).severity === "ERROR") {
-        hasErrors = true;
-        break;
-      }
-    }
-    expect(hasErrors).toBe(false);
+    expect(result.length).toEqual(0);
   });
 
   it("detects missing waveform property in temporal light traits", async function () {
     const result = await validateGltf(
       "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidMissingWaveform.gltf"
     );
-    expect(result.length).toBeGreaterThan(0);
-
-    // Find the error about missing waveform property
-    let foundMissingWaveform = false;
-    for (let i = 0; i < result.length; i++) {
-      const issue = result.get(i);
-      if (
-        issue.type === "INVALID_GLTF_STRUCTURE" &&
-        issue.message.includes("waveform") &&
-        issue.message.includes("required")
-      ) {
-        foundMissingWaveform = true;
-        break;
-      }
-    }
-    expect(foundMissingWaveform).toBe(true);
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("PROPERTY_MISSING");
   });
 
   it("detects invalid waveform value in temporal light traits", async function () {
     const result = await validateGltf(
       "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidWaveform.gltf"
     );
-    expect(result.length).toBeGreaterThan(0);
-
-    // Find the error about invalid waveform value
-    let foundInvalidWaveform = false;
-    for (let i = 0; i < result.length; i++) {
-      const issue = result.get(i);
-      if (
-        issue.type === "INVALID_GLTF_STRUCTURE" &&
-        issue.message.includes("waveform") &&
-        (issue.message.includes("sine") ||
-          issue.message.includes("square") ||
-          issue.message.includes("triangle"))
-      ) {
-        foundInvalidWaveform = true;
-        break;
-      }
-    }
-    expect(foundInvalidWaveform).toBe(true);
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_LIST");
   });
 
   it("detects undeclared MAXAR_temporal_light_traits extension", async function () {
     const result = await validateGltf(
       "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidUndeclaredExtension.gltf"
     );
-    expect(result.length).toBeGreaterThan(0);
-
-    // Find the error about undeclared extension
-    let foundUndeclaredExtension = false;
-    for (let i = 0; i < result.length; i++) {
-      const issue = result.get(i);
-      if (
-        issue.type === "INVALID_GLTF_STRUCTURE" &&
-        issue.message.includes("not declared in extensionsUsed")
-      ) {
-        foundUndeclaredExtension = true;
-        break;
-      }
-    }
-    expect(foundUndeclaredExtension).toBe(true);
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("INVALID_GLTF_STRUCTURE");
   });
 
   it("detects invalid duty property with sine waveform", async function () {
     const result = await validateGltf(
       "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidDutyWithSineWaveform.gltf"
     );
-    expect(result.length).toBeGreaterThan(0);
-
-    // Find the error about duty property only applicable for square waveforms
-    let foundInvalidDuty = false;
-    for (let i = 0; i < result.length; i++) {
-      const issue = result.get(i);
-      if (
-        issue.type === "INVALID_GLTF_STRUCTURE" &&
-        issue.message.includes("duty") &&
-        issue.message.includes("square")
-      ) {
-        foundInvalidDuty = true;
-        break;
-      }
-    }
-    expect(foundInvalidDuty).toBe(true);
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("INVALID_GLTF_STRUCTURE");
   });
 
   it("detects invalid duty property with triangle waveform", async function () {
     const result = await validateGltf(
       "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/invalidDutyWithTriangleWaveform.gltf"
     );
-    expect(result.length).toBeGreaterThan(0);
-
-    // Find the error about duty property only applicable for square waveforms
-    let foundInvalidDuty = false;
-    for (let i = 0; i < result.length; i++) {
-      const issue = result.get(i);
-      if (
-        issue.type === "INVALID_GLTF_STRUCTURE" &&
-        issue.message.includes("duty") &&
-        issue.message.includes("square")
-      ) {
-        foundInvalidDuty = true;
-        break;
-      }
-    }
-    expect(foundInvalidDuty).toBe(true);
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("INVALID_GLTF_STRUCTURE");
   });
 
   it("detects no issues with valid duty property and square waveform", async function () {
     const result = await validateGltf(
       "./specs/data/gltfExtensions/khrLightsPunctual/maxarTemporalLightTraits/validDutyWithSquareWaveform.gltf"
     );
-    // Should only have info messages, no errors
-    let hasErrors = false;
-    for (let i = 0; i < result.length; i++) {
-      if (result.get(i).severity === "ERROR") {
-        hasErrors = true;
-        break;
-      }
-    }
-    expect(hasErrors).toBe(false);
+    expect(result.length).toEqual(0);
   });
 });

--- a/src/validation/gltf/GltfExtensionValidators.ts
+++ b/src/validation/gltf/GltfExtensionValidators.ts
@@ -6,6 +6,7 @@ import { ExtStructuralMetadataValidator } from "./structuralMetadata/ExtStructur
 
 import { GltfDataReader } from "./GltfDataReader";
 import { NgaGpmLocalValidator } from "./gpmLocal/NgaGpmLocalValidator";
+import { KhrLightsPunctualValidator } from "./lightsPunctual/KhrLightsPunctualValidator";
 
 /**
  * A class that only serves as an entry point for validating
@@ -72,6 +73,13 @@ export class GltfExtensionValidators {
       context
     );
     if (!ngaGpmLocalValid) {
+      result = false;
+    }
+
+    // Validate `KHR_lights_punctual`
+    const khrLightsPunctualValid =
+      await KhrLightsPunctualValidator.validateGltf(path, gltfData, context);
+    if (!khrLightsPunctualValid) {
       result = false;
     }
 

--- a/src/validation/gltf/GltfExtensionValidators.ts
+++ b/src/validation/gltf/GltfExtensionValidators.ts
@@ -87,13 +87,13 @@ export class GltfExtensionValidators {
       result = false;
     }
 
-     // Validate `KHR_lights_punctual`
+    // Validate `KHR_lights_punctual`
     const khrLightsPunctualValid =
       await KhrLightsPunctualValidator.validateGltf(path, gltfData, context);
     if (!khrLightsPunctualValid) {
       result = false;
-    }      
-      
+    }
+
     return result;
   }
 }

--- a/src/validation/gltf/lightsPunctual/KhrLightsPunctualValidator.ts
+++ b/src/validation/gltf/lightsPunctual/KhrLightsPunctualValidator.ts
@@ -1,0 +1,136 @@
+import { defined } from "3d-tiles-tools";
+
+import { ValidationContext } from "../../ValidationContext";
+import { BasicValidator } from "../../BasicValidator";
+import { GltfData } from "../GltfData";
+
+import { GltfExtensionValidationIssues } from "../../../issues/GltfExtensionValidationIssues";
+import { MaxarTemporalLightTraitsValidator } from "./MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidator";
+
+/**
+ * A class for validating the `MAXAR_temporal_light_traits` extension
+ * that extends `KHR_lights_punctual` lights in glTF assets.
+ *
+ * This validator only validates MAXAR_temporal_light_traits extensions
+ * and assumes that KHR_lights_punctual structure validation is handled
+ * by the glTF Validator.
+ *
+ * @internal
+ */
+export class KhrLightsPunctualValidator {
+  /**
+   * Performs the validation to ensure that the `MAXAR_temporal_light_traits`
+   * extensions in KHR_lights_punctual lights are valid
+   *
+   * @param path - The path for validation issues
+   * @param gltfData - The glTF data, containing the parsed JSON and the
+   * (optional) binary buffer
+   * @param context - The `ValidationContext` that any issues will be added to
+   * @returns Whether the object was valid
+   */
+  static async validateGltf(
+    path: string,
+    gltfData: GltfData,
+    context: ValidationContext
+  ): Promise<boolean> {
+    const gltf = gltfData.gltf;
+
+    // Check if KHR_lights_punctual extension is used
+    const extensionsUsed = gltf.extensionsUsed;
+    if (!extensionsUsed || !extensionsUsed.includes("KHR_lights_punctual")) {
+      return true; // Extension not used, nothing to validate
+    }
+
+    // Check if MAXAR_temporal_light_traits is also used
+    const hasTemporalTraits = extensionsUsed.includes(
+      "MAXAR_temporal_light_traits"
+    );
+
+    let result = true;
+
+    // Get the root extension to find lights array
+    const rootExtensions = gltf.extensions;
+    let lightsPunctual = undefined;
+    if (defined(rootExtensions)) {
+      lightsPunctual = rootExtensions["KHR_lights_punctual"];
+    }
+
+    // Validate MAXAR_temporal_light_traits extensions in lights
+    // We need to check all lights regardless of whether MAXAR_temporal_light_traits
+    // is declared in extensionsUsed, to catch undeclared usage
+    if (defined(lightsPunctual) && defined(lightsPunctual.lights)) {
+      const lights = lightsPunctual.lights;
+      for (let i = 0; i < lights.length; i++) {
+        const light = lights[i];
+        const lightPath = path + "/extensions/KHR_lights_punctual/lights/" + i;
+        if (
+          !KhrLightsPunctualValidator.validateLightTemporalTraits(
+            lightPath,
+            light,
+            hasTemporalTraits,
+            context
+          )
+        ) {
+          result = false;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Validates MAXAR_temporal_light_traits extensions in a light object
+   *
+   * @param path - The path for validation issues
+   * @param light - The light object
+   * @param hasTemporalTraits - Whether MAXAR_temporal_light_traits extension is used
+   * @param context - The validation context
+   * @returns Whether the light temporal traits are valid
+   */
+  private static validateLightTemporalTraits(
+    path: string,
+    light: any,
+    hasTemporalTraits: boolean,
+    context: ValidationContext
+  ): boolean {
+    // Make sure that the given value is an object
+    if (!BasicValidator.validateObject(path, "light", light, context)) {
+      return false;
+    }
+
+    let result = true;
+
+    // Validate MAXAR_temporal_light_traits extension if present
+    const extensions = light.extensions;
+    if (defined(extensions)) {
+      const temporalTraits = extensions["MAXAR_temporal_light_traits"];
+      if (defined(temporalTraits)) {
+        if (!hasTemporalTraits) {
+          const message =
+            "MAXAR_temporal_light_traits extension is used but not declared in extensionsUsed";
+          const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+            path + "/extensions/MAXAR_temporal_light_traits",
+            message
+          );
+          context.addIssue(issue);
+          result = false;
+        } else {
+          const temporalTraitsPath =
+            path + "/extensions/MAXAR_temporal_light_traits";
+          if (
+            !MaxarTemporalLightTraitsValidator.validateTemporalLightTraits(
+              temporalTraitsPath,
+              temporalTraits,
+              context
+            )
+          ) {
+            result = false;
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/validation/gltf/lightsPunctual/MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidator.ts
+++ b/src/validation/gltf/lightsPunctual/MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidator.ts
@@ -78,67 +78,56 @@ export class MaxarTemporalLightTraitsValidator {
 
     // Validate the waveform property (required)
     const waveform = flashing.waveform;
-    if (!defined(waveform)) {
-      const message = "The 'waveform' property is required";
-      const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
-        path,
-        message
-      );
-      context.addIssue(issue);
+    const validWaveforms = ["sine", "square", "triangle"];
+    if (
+      !BasicValidator.validateEnum(
+        path + "/waveform",
+        "waveform",
+        waveform,
+        validWaveforms,
+        context
+      )
+    ) {
       result = false;
-    } else {
-      const validWaveforms = ["sine", "square", "triangle"];
-      if (typeof waveform !== "string" || !validWaveforms.includes(waveform)) {
-        const message = `The 'waveform' property must be one of: ${validWaveforms.join(
-          ", "
-        )}`;
-        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
-          path + "/waveform",
-          message
-        );
-        context.addIssue(issue);
-        result = false;
-      }
     }
 
     // Validate the frequency property (required)
     const frequency = flashing.frequency;
-    if (!defined(frequency)) {
-      const message = "The 'frequency' property is required";
-      const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
-        path,
-        message
-      );
-      context.addIssue(issue);
+    if (
+      !BasicValidator.validateNumberRange(
+        path + "/frequency",
+        "frequency",
+        frequency,
+        0.0,
+        false,
+        undefined,
+        false,
+        context
+      )
+    ) {
       result = false;
-    } else {
-      if (typeof frequency !== "number" || frequency <= 0) {
-        const message = "The 'frequency' property must be a positive number";
-        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
-          path + "/frequency",
-          message
-        );
-        context.addIssue(issue);
-        result = false;
-      }
     }
 
     // Validate the duty property (optional)
     const duty = flashing.duty;
     if (defined(duty)) {
-      if (typeof duty !== "number" || duty < 0.0 || duty > 1.0) {
-        const message =
-          "The 'duty' property must be a number between 0.0 and 1.0";
-        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+      if (
+        !BasicValidator.validateNumberRange(
           path + "/duty",
-          message
-        );
-        context.addIssue(issue);
+          "duty",
+          duty,
+          0.0,
+          true,
+          1.0,
+          true,
+          context
+        )
+      ) {
         result = false;
       }
 
       // Validate that duty is only used with square waveforms
-      if (defined(waveform) && waveform !== "square") {
+      if (waveform !== "square") {
         const message =
           "The 'duty' property is only applicable for 'square' waveforms";
         const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
@@ -153,13 +142,14 @@ export class MaxarTemporalLightTraitsValidator {
     // Validate the amplitudeOffset property (optional)
     const amplitudeOffset = flashing.amplitudeOffset;
     if (defined(amplitudeOffset)) {
-      if (typeof amplitudeOffset !== "number") {
-        const message = "The 'amplitudeOffset' property must be a number";
-        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+      if (
+        !BasicValidator.validateNumber(
           path + "/amplitudeOffset",
-          message
-        );
-        context.addIssue(issue);
+          "amplitudeOffset",
+          amplitudeOffset,
+          context
+        )
+      ) {
         result = false;
       }
     }
@@ -167,13 +157,14 @@ export class MaxarTemporalLightTraitsValidator {
     // Validate the amplitudeScale property (optional)
     const amplitudeScale = flashing.amplitudeScale;
     if (defined(amplitudeScale)) {
-      if (typeof amplitudeScale !== "number") {
-        const message = "The 'amplitudeScale' property must be a number";
-        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+      if (
+        !BasicValidator.validateNumber(
           path + "/amplitudeScale",
-          message
-        );
-        context.addIssue(issue);
+          "amplitudeScale",
+          amplitudeScale,
+          context
+        )
+      ) {
         result = false;
       }
     }
@@ -181,13 +172,14 @@ export class MaxarTemporalLightTraitsValidator {
     // Validate the phaseOffset property (optional)
     const phaseOffset = flashing.phaseOffset;
     if (defined(phaseOffset)) {
-      if (typeof phaseOffset !== "number") {
-        const message = "The 'phaseOffset' property must be a number";
-        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+      if (
+        !BasicValidator.validateNumber(
           path + "/phaseOffset",
-          message
-        );
-        context.addIssue(issue);
+          "phaseOffset",
+          phaseOffset,
+          context
+        )
+      ) {
         result = false;
       }
     }

--- a/src/validation/gltf/lightsPunctual/MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidator.ts
+++ b/src/validation/gltf/lightsPunctual/MaxarTemporalLightTraits/MaxarTemporalLightTraitsValidator.ts
@@ -1,0 +1,197 @@
+import { defined } from "3d-tiles-tools";
+
+import { ValidationContext } from "../../../ValidationContext";
+import { BasicValidator } from "../../../BasicValidator";
+
+import { GltfExtensionValidationIssues } from "../../../../issues/GltfExtensionValidationIssues";
+
+/**
+ * A class for validating the `MAXAR_temporal_light_traits` extension
+ * that extends `KHR_lights_punctual` lights.
+ *
+ * @internal
+ */
+export class MaxarTemporalLightTraitsValidator {
+  /**
+   * Validates the MAXAR_temporal_light_traits extension
+   *
+   * @param path - The path for validation issues
+   * @param extension - The temporal light traits extension object
+   * @param context - The validation context
+   * @returns Whether the extension is valid
+   */
+  static validateTemporalLightTraits(
+    path: string,
+    extension: any,
+    context: ValidationContext
+  ): boolean {
+    // Make sure that the given value is an object
+    if (
+      !BasicValidator.validateObject(
+        path,
+        "MAXAR_temporal_light_traits",
+        extension,
+        context
+      )
+    ) {
+      return false;
+    }
+
+    let result = true;
+
+    // Validate the flashing property (optional)
+    const flashing = extension.flashing;
+    if (defined(flashing)) {
+      if (
+        !MaxarTemporalLightTraitsValidator.validateFlashing(
+          path + "/flashing",
+          flashing,
+          context
+        )
+      ) {
+        result = false;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Validates a flashing trait object
+   *
+   * @param path - The path for validation issues
+   * @param flashing - The flashing object
+   * @param context - The validation context
+   * @returns Whether the flashing trait is valid
+   */
+  private static validateFlashing(
+    path: string,
+    flashing: any,
+    context: ValidationContext
+  ): boolean {
+    // Make sure that the given value is an object
+    if (!BasicValidator.validateObject(path, "flashing", flashing, context)) {
+      return false;
+    }
+
+    let result = true;
+
+    // Validate the waveform property (required)
+    const waveform = flashing.waveform;
+    if (!defined(waveform)) {
+      const message = "The 'waveform' property is required";
+      const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+        path,
+        message
+      );
+      context.addIssue(issue);
+      result = false;
+    } else {
+      const validWaveforms = ["sine", "square", "triangle"];
+      if (typeof waveform !== "string" || !validWaveforms.includes(waveform)) {
+        const message = `The 'waveform' property must be one of: ${validWaveforms.join(
+          ", "
+        )}`;
+        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+          path + "/waveform",
+          message
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+    }
+
+    // Validate the frequency property (required)
+    const frequency = flashing.frequency;
+    if (!defined(frequency)) {
+      const message = "The 'frequency' property is required";
+      const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+        path,
+        message
+      );
+      context.addIssue(issue);
+      result = false;
+    } else {
+      if (typeof frequency !== "number" || frequency <= 0) {
+        const message = "The 'frequency' property must be a positive number";
+        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+          path + "/frequency",
+          message
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+    }
+
+    // Validate the duty property (optional)
+    const duty = flashing.duty;
+    if (defined(duty)) {
+      if (typeof duty !== "number" || duty < 0.0 || duty > 1.0) {
+        const message =
+          "The 'duty' property must be a number between 0.0 and 1.0";
+        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+          path + "/duty",
+          message
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+
+      // Validate that duty is only used with square waveforms
+      if (defined(waveform) && waveform !== "square") {
+        const message =
+          "The 'duty' property is only applicable for 'square' waveforms";
+        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+          path + "/duty",
+          message
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+    }
+
+    // Validate the amplitudeOffset property (optional)
+    const amplitudeOffset = flashing.amplitudeOffset;
+    if (defined(amplitudeOffset)) {
+      if (typeof amplitudeOffset !== "number") {
+        const message = "The 'amplitudeOffset' property must be a number";
+        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+          path + "/amplitudeOffset",
+          message
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+    }
+
+    // Validate the amplitudeScale property (optional)
+    const amplitudeScale = flashing.amplitudeScale;
+    if (defined(amplitudeScale)) {
+      if (typeof amplitudeScale !== "number") {
+        const message = "The 'amplitudeScale' property must be a number";
+        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+          path + "/amplitudeScale",
+          message
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+    }
+
+    // Validate the phaseOffset property (optional)
+    const phaseOffset = flashing.phaseOffset;
+    if (defined(phaseOffset)) {
+      if (typeof phaseOffset !== "number") {
+        const message = "The 'phaseOffset' property must be a number";
+        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+          path + "/phaseOffset",
+          message
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
- Add dedicated validator for MAXAR_temporal_light_traits extension that extends KHR_lights_punctual
- Validate flashing trait properties including waveform types, frequency, duty cycle, amplitude and phase
- Ensure extension is properly declared in extensionsUsed array
- Organize code with modular structure using MaxarTemporalLightTraitsValidator
- Include focused test suite with valid and invalid test cases
- Assume base KHR_lights_punctual validation is handled by glTF Validator