### PR TITLE
Add MAXAR_nonvisual_geometry glTF extension validator

### DIFF
--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshInvalidType.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshInvalidType.gltf
@@ -1,0 +1,55 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Node extension mesh property has invalid type (string instead of integer)"
+    }
+  },
+  "nodes": [{
+    "name": "Test Node",
+    "extensions": {
+      "MAXAR_nonvisual_geometry": {
+        "mesh": "invalid"
+      }
+    }
+  }],
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshInvalidValue.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshInvalidValue.gltf
@@ -1,0 +1,55 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Node extension mesh property has invalid value (negative integer)"
+    }
+  },
+  "nodes": [{
+    "name": "Test Node",
+    "extensions": {
+      "MAXAR_nonvisual_geometry": {
+        "mesh": -1
+      }
+    }
+  }],
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshMissing.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshMissing.gltf
@@ -1,0 +1,54 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Node extension missing required mesh property"
+    }
+  },
+  "nodes": [{
+    "name": "Test Node",
+    "extensions": {
+      "MAXAR_nonvisual_geometry": {
+      }
+    }
+  }],
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshNotFound.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshNotFound.gltf
@@ -1,0 +1,55 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Node extension mesh property references non-existent mesh"
+    }
+  },
+  "nodes": [{
+    "name": "Test Node",
+    "extensions": {
+      "MAXAR_nonvisual_geometry": {
+        "mesh": 5
+      }
+    }
+  }],
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeInvalidType.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeInvalidType.gltf
@@ -1,0 +1,56 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Primitive extension shape property has invalid type (number instead of string)"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": 123,
+          "type": "collision"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeInvalidValue.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeInvalidValue.gltf
@@ -1,0 +1,56 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Primitive extension shape property has invalid enum value"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "invalid_shape",
+          "type": "collision"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeMissing.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeMissing.gltf
@@ -1,0 +1,55 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Primitive extension missing required shape property"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "type": "collision"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeEmpty.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeEmpty.gltf
@@ -1,0 +1,56 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Primitive extension type property is empty string"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "surface",
+          "type": ""
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeInvalidType.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeInvalidType.gltf
@@ -1,0 +1,56 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Primitive extension type property has invalid type (number instead of string)"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "surface",
+          "type": 123
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeMissing.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeMissing.gltf
@@ -1,0 +1,55 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Primitive extension missing required type property"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "surface"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ShapePathIncompatibleMode.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ShapePathIncompatibleMode.gltf
@@ -1,0 +1,57 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Path shape with incompatible primitive mode (TRIANGLES instead of LINES/LINE_LOOP/LINE_STRIP)"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "mode": 4,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "path",
+          "type": "ladder"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ShapePointsIncompatibleMode.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ShapePointsIncompatibleMode.gltf
@@ -1,0 +1,57 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Points shape with incompatible primitive mode (TRIANGLES instead of POINTS)"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "mode": 4,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "points",
+          "type": "trigger"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ShapeSurfaceIncompatibleMode.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ShapeSurfaceIncompatibleMode.gltf
@@ -1,0 +1,47 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Surface shape with incompatible primitive mode (POINTS instead of TRIANGLES/TRIANGLE_STRIP/TRIANGLE_FAN)"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "mode": 0,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "surface",
+          "type": "roadway"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAA=",
+    "byteLength": 36
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ShapeVolumeIncompatibleMode.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ShapeVolumeIncompatibleMode.gltf
@@ -1,0 +1,57 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Volume shape with incompatible primitive mode (TRIANGLE_FAN instead of TRIANGLES/TRIANGLE_STRIP)"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "mode": 6,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "volume",
+          "type": "collision"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidComplexExample.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidComplexExample.gltf
@@ -1,0 +1,168 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Complex example with node extension and multiple primitive extensions"
+    }
+  },
+  "nodes": [{
+    "name": "Building",
+    "mesh": 0,
+    "extensions": {
+      "MAXAR_nonvisual_geometry": {
+        "mesh": 1
+      }
+    }
+  }],
+  "meshes": [{
+    "name": "Visual Building Mesh",
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0,
+        "NORMAL": 1
+      },
+      "indices": 2
+    }]
+  }, {
+    "name": "Nonvisual Building Mesh",
+    "primitives": [{
+      "attributes": {
+        "POSITION": 3
+      },
+      "indices": 4,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "surface",
+          "type": "roadway"
+        }
+      }
+    }, {
+      "attributes": {
+        "POSITION": 5
+      },
+      "mode": 3,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "path",
+          "type": "ladder"
+        }
+      }
+    }, {
+      "attributes": {
+        "POSITION": 6
+      },
+      "indices": 7,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "volume",
+          "type": "collision"
+        }
+      }
+    }, {
+      "attributes": {
+        "POSITION": 8
+      },
+      "mode": 0,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "points",
+          "type": "trigger"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 2,
+    "componentType": 5123,
+    "count": 6,
+    "type": "SCALAR"
+  }, {
+    "bufferView": 3,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 4,
+    "componentType": 5123,
+    "count": 6,
+    "type": "SCALAR"
+  }, {
+    "bufferView": 5,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 6,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 7,
+    "componentType": 5123,
+    "count": 12,
+    "type": "SCALAR"
+  }, {
+    "bufferView": 8,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 48,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 96,
+    "byteLength": 12
+  }, {
+    "buffer": 0,
+    "byteOffset": 108,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 156,
+    "byteLength": 12
+  }, {
+    "buffer": 0,
+    "byteOffset": 168,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 216,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 264,
+    "byteLength": 24
+  }, {
+    "buffer": 0,
+    "byteOffset": 288,
+    "byteLength": 36
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAgD8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAABAAIAAwAAAAEAAgAAAAAAAAAAAACAPwAAAAAAAIA/AAAAAAAAgD8AAIA/AAAAAAAAAAAAAAAAAAABAAIAAQADAAIAAAAAAAAAAAAAAAAAAACAP2ZmZj8AAAAAAAAAAAAAAAAAAIA/ZmZmPwAAAAAAAAAAAACAPwAAAAAAAIA/AAAAAAAAgD8AAIA/AAAAAAAAAAAAAAAAAAABAAIAAQADAAIAAAABAAMAAQAAAAMAAAACAAMAAAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAA=",
+    "byteLength": 324
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidNodeExtension.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidNodeExtension.gltf
@@ -1,0 +1,99 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Valid node extension referencing existing mesh"
+    }
+  },
+  "nodes": [{
+    "name": "Visual Node",
+    "mesh": 0,
+    "extensions": {
+      "MAXAR_nonvisual_geometry": {
+        "mesh": 1
+      }
+    }
+  }],
+  "meshes": [{
+    "name": "Visual Mesh",
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0,
+        "NORMAL": 1
+      },
+      "indices": 2
+    }]
+  }, {
+    "name": "Nonvisual Mesh",
+    "primitives": [{
+      "attributes": {
+        "POSITION": 3
+      },
+      "indices": 4,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "surface",
+          "type": "collision"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 2,
+    "componentType": 5123,
+    "count": 6,
+    "type": "SCALAR"
+  }, {
+    "bufferView": 3,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 4,
+    "componentType": 5123,
+    "count": 6,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 48,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 96,
+    "byteLength": 12
+  }, {
+    "buffer": 0,
+    "byteOffset": 108,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 156,
+    "byteLength": 12
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAABAAIAAwAAAAEAAgAAAAAAAAAAAACAPwAAAAAAAIA/AAAAAAAAgD8AAIA/AAAAAAAAAAAAAAAAAAABAAIAAQADAAIA",
+    "byteLength": 168
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionPath.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionPath.gltf
@@ -1,0 +1,47 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Valid primitive extension with path shape and LINE_STRIP mode"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "mode": 3,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "path",
+          "type": "ladder"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 48
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAgD8AAAAAAAAAAAAAAAA=",
+    "byteLength": 48
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionPoints.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionPoints.gltf
@@ -1,0 +1,47 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Valid primitive extension with points shape and POINTS mode"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "mode": 0,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "points",
+          "type": "trigger"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAA=",
+    "byteLength": 36
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionSurface.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionSurface.gltf
@@ -1,0 +1,57 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Valid primitive extension with surface shape and TRIANGLES mode"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "mode": 4,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "surface",
+          "type": "roadway"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 3,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  }, {
+    "buffer": 0,
+    "byteOffset": 36,
+    "byteLength": 6
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAEAAgA=",
+    "byteLength": 42
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionVolume.gltf
+++ b/specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionVolume.gltf
@@ -1,0 +1,57 @@
+{
+  "extensionsUsed": ["MAXAR_nonvisual_geometry"],
+  "asset": {
+    "version": "2.0"
+  },
+  "extras": {
+    "info": {
+      "note": "Valid primitive extension with volume shape and TRIANGLES mode"
+    }
+  },
+  "meshes": [{
+    "primitives": [{
+      "attributes": {
+        "POSITION": 0
+      },
+      "indices": 1,
+      "mode": 4,
+      "extensions": {
+        "MAXAR_nonvisual_geometry": {
+          "shape": "volume",
+          "type": "collision"
+        }
+      }
+    }]
+  }],
+  "accessors": [{
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 4,
+    "type": "VEC3"
+  }, {
+    "bufferView": 1,
+    "componentType": 5123,
+    "count": 12,
+    "type": "SCALAR"
+  }],
+  "bufferViews": [{
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 48
+  }, {
+    "buffer": 0,
+    "byteOffset": 48,
+    "byteLength": 24
+  }],
+  "buffers": [{
+    "uri": "data:application/gltf-buffer;base64,AAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAACAPwAAgD8AAAAAAAAAAAAAAAAAAAAAAAABAAIAAQADAAIAAAABAAMAAQAAAAMAAAACAAMAAA==",
+    "byteLength": 72
+  }],
+  "nodes": [{
+    "mesh": 0
+  }],
+  "scene": 0,
+  "scenes": [{
+    "nodes": [0]
+  }]
+}

--- a/specs/gltfExtensions/MaxarNonvisualGeometryValidationSpec.ts
+++ b/specs/gltfExtensions/MaxarNonvisualGeometryValidationSpec.ts
@@ -1,0 +1,157 @@
+import { validateGltf } from "./validateGltf";
+
+describe("MAXAR_nonvisual_geometry extension validation", function () {
+  it("detects issues in NodeExtensionMeshMissing", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshMissing.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("PROPERTY_MISSING");
+  });
+
+  it("detects issues in NodeExtensionMeshInvalidType", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshInvalidType.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in NodeExtensionMeshInvalidValue", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshInvalidValue.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_RANGE");
+  });
+
+  it("detects issues in NodeExtensionMeshNotFound", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/NodeExtensionMeshNotFound.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("IDENTIFIER_NOT_FOUND");
+  });
+
+  it("detects issues in PrimitiveExtensionShapeMissing", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeMissing.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("PROPERTY_MISSING");
+  });
+
+  it("detects issues in PrimitiveExtensionShapeInvalidType", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeInvalidType.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_LIST");
+  });
+
+  it("detects issues in PrimitiveExtensionShapeInvalidValue", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionShapeInvalidValue.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("VALUE_NOT_IN_LIST");
+  });
+
+  it("detects issues in PrimitiveExtensionTypeMissing", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeMissing.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("PROPERTY_MISSING");
+  });
+
+  it("detects issues in PrimitiveExtensionTypeInvalidType", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeInvalidType.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("TYPE_MISMATCH");
+  });
+
+  it("detects issues in PrimitiveExtensionTypeEmpty", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/PrimitiveExtensionTypeEmpty.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("INVALID_GLTF_STRUCTURE");
+  });
+
+  it("detects issues in ShapePointsIncompatibleMode", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ShapePointsIncompatibleMode.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("INVALID_GLTF_STRUCTURE");
+  });
+
+  it("detects issues in ShapePathIncompatibleMode", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ShapePathIncompatibleMode.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("INVALID_GLTF_STRUCTURE");
+  });
+
+  it("detects issues in ShapeSurfaceIncompatibleMode", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ShapeSurfaceIncompatibleMode.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("INVALID_GLTF_STRUCTURE");
+  });
+
+  it("detects issues in ShapeVolumeIncompatibleMode", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ShapeVolumeIncompatibleMode.gltf"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("INVALID_GLTF_STRUCTURE");
+  });
+
+  it("validates ValidNodeExtension", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ValidNodeExtension.gltf"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("validates ValidPrimitiveExtensionPoints", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionPoints.gltf"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("validates ValidPrimitiveExtensionPath", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionPath.gltf"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("validates ValidPrimitiveExtensionSurface", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionSurface.gltf"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("validates ValidPrimitiveExtensionVolume", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ValidPrimitiveExtensionVolume.gltf"
+    );
+    expect(result.length).toEqual(0);
+  });
+
+  it("validates ValidComplexExample", async function () {
+    const result = await validateGltf(
+      "./specs/data/gltfExtensions/maxarNonvisualGeometry/ValidComplexExample.gltf"
+    );
+    expect(result.length).toEqual(0);
+  });
+});

--- a/src/validation/gltf/GltfExtensionValidators.ts
+++ b/src/validation/gltf/GltfExtensionValidators.ts
@@ -3,6 +3,7 @@ import { ValidationContext } from "../ValidationContext";
 import { ExtInstanceFeaturesValidator } from "./instanceFeatures/ExtInstanceFeaturesValidator";
 import { ExtMeshFeaturesValidator } from "./meshFeatures/ExtMeshFeaturesValidator";
 import { ExtStructuralMetadataValidator } from "./structuralMetadata/ExtStructuralMetadataValidator";
+import { MaxarNonvisualGeometryValidator } from "./nonvisualGeometry/MaxarNonvisualGeometryValidator";
 
 import { GltfDataReader } from "./GltfDataReader";
 import { NgaGpmLocalValidator } from "./gpmLocal/NgaGpmLocalValidator";
@@ -72,6 +73,17 @@ export class GltfExtensionValidators {
       context
     );
     if (!ngaGpmLocalValid) {
+      result = false;
+    }
+
+    // Validate `MAXAR_nonvisual_geometry`
+    const maxarNonvisualGeometryValid =
+      await MaxarNonvisualGeometryValidator.validateGltf(
+        path,
+        gltfData,
+        context
+      );
+    if (!maxarNonvisualGeometryValid) {
       result = false;
     }
 

--- a/src/validation/gltf/nonvisualGeometry/MaxarNonvisualGeometryValidator.ts
+++ b/src/validation/gltf/nonvisualGeometry/MaxarNonvisualGeometryValidator.ts
@@ -1,0 +1,333 @@
+import { defined } from "3d-tiles-tools";
+
+import { ValidationContext } from "../../ValidationContext";
+import { BasicValidator } from "../../BasicValidator";
+
+import { GltfData } from "../GltfData";
+
+import { GltfExtensionValidationIssues } from "../../../issues/GltfExtensionValidationIssues";
+import { StructureValidationIssues } from "../../../issues/StructureValidationIssues";
+
+/**
+ * A class for validating the `MAXAR_nonvisual_geometry` extension in
+ * glTF assets.
+ *
+ * This class assumes that the structure of the glTF asset itself
+ * has already been validated (e.g. with the glTF Validator).
+ *
+ * @internal
+ */
+export class MaxarNonvisualGeometryValidator {
+  /**
+   * Performs the validation to ensure that the `MAXAR_nonvisual_geometry`
+   * extensions in the given glTF are valid
+   *
+   * @param path - The path for validation issues
+   * @param gltfData - The glTF data, containing the parsed JSON and the
+   * (optional) binary buffer
+   * @param context - The `ValidationContext` that any issues will be added to
+   * @returns Whether the object was valid
+   */
+  static async validateGltf(
+    path: string,
+    gltfData: GltfData,
+    context: ValidationContext
+  ): Promise<boolean> {
+    const gltf = gltfData.gltf;
+    let result = true;
+
+    // Validate node extensions
+    const nodes = gltf.nodes || [];
+    for (let n = 0; n < nodes.length; n++) {
+      const node = nodes[n];
+      if (!node) {
+        continue;
+      }
+      const extensions = node.extensions;
+      if (!extensions) {
+        continue;
+      }
+      const nonvisualGeometry = extensions["MAXAR_nonvisual_geometry"];
+      if (defined(nonvisualGeometry)) {
+        const nodePath =
+          path + "/nodes/" + n + "/extensions/MAXAR_nonvisual_geometry";
+        const objectIsValid =
+          MaxarNonvisualGeometryValidator.validateNodeExtension(
+            nodePath,
+            nonvisualGeometry,
+            gltf,
+            context
+          );
+        if (!objectIsValid) {
+          result = false;
+        }
+      }
+    }
+
+    // Validate mesh primitive extensions
+    const meshes = gltf.meshes || [];
+    for (let m = 0; m < meshes.length; m++) {
+      const mesh = meshes[m];
+      if (!mesh) {
+        continue;
+      }
+      const primitives = mesh.primitives;
+      if (!primitives || !Array.isArray(primitives)) {
+        continue;
+      }
+      for (let p = 0; p < primitives.length; p++) {
+        const primitive = primitives[p];
+        if (!primitive) {
+          continue;
+        }
+        const extensions = primitive.extensions;
+        if (!extensions) {
+          continue;
+        }
+        const nonvisualGeometry = extensions["MAXAR_nonvisual_geometry"];
+        if (defined(nonvisualGeometry)) {
+          const primitivePath =
+            path +
+            "/meshes/" +
+            m +
+            "/primitives/" +
+            p +
+            "/extensions/MAXAR_nonvisual_geometry";
+          const objectIsValid =
+            MaxarNonvisualGeometryValidator.validatePrimitiveExtension(
+              primitivePath,
+              nonvisualGeometry,
+              primitive,
+              context
+            );
+          if (!objectIsValid) {
+            result = false;
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Validate the given MAXAR_nonvisual_geometry extension object that was
+   * found in a glTF node.
+   *
+   * @param path - The path for validation issues
+   * @param nodeExtension - The MAXAR_nonvisual_geometry extension object
+   * @param gltf - The glTF root object
+   * @param context - The `ValidationContext` that any issues will be added to
+   * @returns Whether the object was valid
+   */
+  private static validateNodeExtension(
+    path: string,
+    nodeExtension: any,
+    gltf: any,
+    context: ValidationContext
+  ): boolean {
+    // Make sure that the given value is an object
+    if (
+      !BasicValidator.validateObject(
+        path,
+        "nodeExtension",
+        nodeExtension,
+        context
+      )
+    ) {
+      return false;
+    }
+
+    let result = true;
+
+    // Validate the mesh property
+    const mesh = nodeExtension.mesh;
+    const meshPath = path + "/mesh";
+
+    // The mesh property is required
+    if (!BasicValidator.validateDefined(meshPath, "mesh", mesh, context)) {
+      result = false;
+    } else {
+      // The mesh must be a valid glTF ID (non-negative integer)
+      if (
+        !BasicValidator.validateIntegerRange(
+          meshPath,
+          "mesh",
+          mesh,
+          0,
+          true,
+          undefined,
+          false,
+          context
+        )
+      ) {
+        result = false;
+      } else {
+        // Validate that the mesh index references an existing mesh
+        const meshes = gltf.meshes || [];
+        if (mesh >= meshes.length) {
+          const message =
+            `The mesh index ${mesh} is out of range. ` +
+            `The glTF contains ${meshes.length} meshes.`;
+          const issue = StructureValidationIssues.IDENTIFIER_NOT_FOUND(
+            meshPath,
+            message
+          );
+          context.addIssue(issue);
+          result = false;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Validate the given MAXAR_nonvisual_geometry extension object that was
+   * found in a mesh primitive.
+   *
+   * @param path - The path for validation issues
+   * @param primitiveExtension - The MAXAR_nonvisual_geometry extension object
+   * @param primitive - The mesh primitive that contains the extension
+   * @param context - The `ValidationContext` that any issues will be added to
+   * @returns Whether the object was valid
+   */
+  private static validatePrimitiveExtension(
+    path: string,
+    primitiveExtension: any,
+    primitive: any,
+    context: ValidationContext
+  ): boolean {
+    // Make sure that the given value is an object
+    if (
+      !BasicValidator.validateObject(
+        path,
+        "primitiveExtension",
+        primitiveExtension,
+        context
+      )
+    ) {
+      return false;
+    }
+
+    let result = true;
+
+    // Validate the shape property
+    const shape = primitiveExtension.shape;
+    const shapePath = path + "/shape";
+
+    // The shape property is required
+    if (!BasicValidator.validateDefined(shapePath, "shape", shape, context)) {
+      result = false;
+    } else {
+      // The shape must be one of the allowed enum values
+      const allowedShapes = ["points", "path", "surface", "volume"];
+      if (
+        !BasicValidator.validateEnum(
+          shapePath,
+          "shape",
+          shape,
+          allowedShapes,
+          context
+        )
+      ) {
+        result = false;
+      } else {
+        // Validate shape-to-primitive-mode compatibility
+        const shapeCompatibilityValid =
+          MaxarNonvisualGeometryValidator.validateShapeCompatibility(
+            path,
+            shape,
+            primitive,
+            context
+          );
+        if (!shapeCompatibilityValid) {
+          result = false;
+        }
+      }
+    }
+
+    // Validate the type property
+    const type = primitiveExtension.type;
+    const typePath = path + "/type";
+
+    // The type property is required
+    if (!BasicValidator.validateDefined(typePath, "type", type, context)) {
+      result = false;
+    } else {
+      // The type must be a non-empty string
+      if (
+        !BasicValidator.validateType(typePath, "type", type, "string", context)
+      ) {
+        result = false;
+      } else if (type.length === 0) {
+        const message = "The type property must be a non-empty string";
+        const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+          typePath,
+          message
+        );
+        context.addIssue(issue);
+        result = false;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Validate that the shape is compatible with the primitive mode.
+   *
+   * @param path - The path for validation issues
+   * @param shape - The shape value from the extension
+   * @param primitive - The mesh primitive
+   * @param context - The `ValidationContext` that any issues will be added to
+   * @returns Whether the shape is compatible with the primitive mode
+   */
+  private static validateShapeCompatibility(
+    path: string,
+    shape: string,
+    primitive: any,
+    context: ValidationContext
+  ): boolean {
+    const mode = primitive.mode !== undefined ? primitive.mode : 4; // Default to TRIANGLES (4)
+
+    let allowedModes: number[] = [];
+    let shapeDescription = "";
+
+    switch (shape) {
+      case "points":
+        allowedModes = [0]; // POINTS
+        shapeDescription = "Points shape requires primitive mode 0 (POINTS)";
+        break;
+      case "path":
+        allowedModes = [1, 2, 3]; // LINES, LINE_LOOP, LINE_STRIP
+        shapeDescription =
+          "Path shape requires primitive mode 1 (LINES), 2 (LINE_LOOP), or 3 (LINE_STRIP)";
+        break;
+      case "surface":
+        allowedModes = [4, 5, 6]; // TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN
+        shapeDescription =
+          "Surface shape requires primitive mode 4 (TRIANGLES), 5 (TRIANGLE_STRIP), or 6 (TRIANGLE_FAN)";
+        break;
+      case "volume":
+        allowedModes = [4, 5]; // TRIANGLES, TRIANGLE_STRIP
+        shapeDescription =
+          "Volume shape requires primitive mode 4 (TRIANGLES) or 5 (TRIANGLE_STRIP)";
+        break;
+    }
+
+    if (!allowedModes.includes(mode)) {
+      const message =
+        `Shape '${shape}' is not compatible with primitive mode ${mode}. ` +
+        shapeDescription;
+      const issue = GltfExtensionValidationIssues.INVALID_GLTF_STRUCTURE(
+        path,
+        message
+      );
+      context.addIssue(issue);
+      return false;
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
- Implement MaxarNonvisualGeometryValidator for node and mesh primitive extensions
- Validate required properties: mesh (node), shape and type (primitive)
- Enforce shape-to-primitive-mode compatibility rules
- Add comprehensive test suite with test cases covering valid/invalid scenarios
- Integrate with GltfExtensionValidators validation pipeline