### PR TITLE
Let linting fail for warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "about:package-copy": "echo 'Copy the entry point for the application from the bin to the build directory'",
     "about:package": "echo 'Prepare a package that can then be published on NPM'",
     "start": "npx ts-node src/main.ts",
-    "eslint": "eslint \"./**/*.ts\" --cache",
+    "eslint": "eslint \"./**/*.ts\" --cache --max-warnings=0",
     "build": "npx tsc",
     "test": "ts-node node_modules/jasmine/bin/jasmine --config=specs/jasmine.json",
     "coverage": "nyc npm run test",


### PR DESCRIPTION
Until now, the `eslint` step did not fail when it encountered warnings, because in this case, the exit code still was `0`.

Apparently, [setting `--max-warnings=0`](https://github.com/eslint/eslint/issues/2309#issuecomment-219828044) is considered a reasonable workaround for this. From local tests, it looks like this indeed causes the exit code to become `1` in the case of warnings, which should cause the CI build to fail.
