### PR TITLE
Validate `extensionsRequired` declaration

### DIFF
--- a/specs/TilesetValidationSpec.ts
+++ b/specs/TilesetValidationSpec.ts
@@ -1021,6 +1021,14 @@ describe("Tileset validation", function () {
     expect(result.length).toEqual(0);
   });
 
+  it("detects issues in extensionNotDeclaredAsRequired", async function () {
+    const result = await Validators.validateTilesetFile(
+      "specs/data/tilesets/extensionNotDeclaredAsRequired.json"
+    );
+    expect(result.length).toEqual(1);
+    expect(result.get(0).type).toEqual("EXTENSION_REQUIRED_BUT_NOT_DECLARED");
+  });
+
   it("detects issues in extensionRequiredButNotUsed", async function () {
     const result = await Validators.validateTilesetFile(
       "specs/data/tilesets/extensionRequiredButNotUsed.json"

--- a/specs/data/tilesets/extensionNotDeclaredAsRequired.json
+++ b/specs/data/tilesets/extensionNotDeclaredAsRequired.json
@@ -1,0 +1,24 @@
+{
+  "extras": {
+    "info": {
+      "note": "This tileset is INVALID because it uses the MAXAR_content_3tz extension, but does not list it in the 'extensionsRequired'"
+    }
+  },
+  "extensionsUsed": [
+    "MAXAR_content_3tz"
+  ],
+  "asset" : {
+    "version" : "1.1"
+  },
+  "geometricError" : 2.0,
+  "root" : {
+    "refine": "REPLACE",
+    "boundingVolume" : {
+      "box" : [ 0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5 ]
+    },
+    "geometricError" : 1.0,
+    "content": {
+      "uri": "tiles/3tz/simple.3tz"
+    }
+  }
+}

--- a/specs/extensions/MaxarContentGeojonValidationSpec.ts
+++ b/specs/extensions/MaxarContentGeojonValidationSpec.ts
@@ -5,15 +5,14 @@ describe("Tileset MAXAR_content_geojson extension validation", function () {
     const result = await Validators.validateTilesetFile(
       "specs/data/extensions/maxarContentGeojson/invalidTilesetWithGeojson.json"
     );
-    // Expect validation error because GeoJSON content is used without
+    // Expect validation errors because GeoJSON content is used without
     // declaring the MAXAR_content_geojson extension in extensionsUsed
-    expect(result.length).toEqual(1);
+    // and extensionsRequired
+    expect(result.length).toEqual(2);
 
-    // Should have content validation error for undeclared extension
-    expect(result.get(0).type).toEqual("CONTENT_VALIDATION_ERROR");
-    expect(result.get(0).message).toContain(
-      "GeoJSON content is not valid by default"
-    );
+    // Should have content validation errors for undeclared extension
+    expect(result.get(0).type).toEqual("EXTENSION_FOUND_BUT_NOT_USED");
+    expect(result.get(1).type).toEqual("EXTENSION_REQUIRED_BUT_NOT_DECLARED");
   });
 
   it("detects error when extension is in extensionsUsed but not in extensionsRequired", async function () {

--- a/src/issues/SemanticValidationIssues.ts
+++ b/src/issues/SemanticValidationIssues.ts
@@ -364,7 +364,9 @@ export class SemanticValidationIssues {
    *
    * An extension is 'found' when it is encountered in any
    * 'someRootProperty.extensions' dictionary during the
-   * traversal,
+   * traversal, or when it is an extension that allows a
+   * new content type, and this type has been encountered
+   * as a tile content.
    *
    * @param path - The path for the `ValidationIssue`
    * @param extensionName - The extension name


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles-validator/issues/345

The validator did not detect the case where an extension was 'required', but not listed in the `extensionsRequired`. There is no technical mechanism for "marking" an extension as 'required' in the validator. The special case of the `3DTILES_content_gltf` extension being required for 3D Tiles 1.0 but not for 1.1, raises some additional questions for this, and these are tracked in https://github.com/CesiumGS/3d-tiles-validator/issues/231.

For now, the extensions that are known to be required - `MAXAR_content_3tz` and `MAXAR_content_geojson` - are listed here explicitly. A test for the 3TZ case has been added, and the existing test for the GeoJSON case has been updated accordingly.
