### PR TITLE
Resolve semanticSchemaFileNames relative to options file

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ In order to include a 'semantics schema' in the validation process, the name of 
 }
 ```
 
+Note: Relative paths in the `semanticSchemaFileNames` array are resolved relative to the directory of the options file (`--optionsFile`)
+
+
 This options file can then be passed to the validator:
 ```
 npx 3d-tiles-validator --optionsFile exampleOptions.json -t ./data/exampleTileset.json

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { readJsonUnchecked } from "./base/readJsonUnchecked";
 import { ValidationOptions } from "./validation/ValidationOptions";
 
 import { ValidatorMain } from "./ValidatorMain";
+import path from "path";
 
 const args = yargs(process.argv.slice(1))
   .help("help")
@@ -96,6 +97,16 @@ async function readOptionsFile(
   if (!validationOptionsObject) {
     return new ValidationOptions();
   }
+
+  // Resolve semanticSchemaFileNames relative to the options file location
+  const baseDir = path.dirname(optionsFile);
+  if (Array.isArray(validationOptionsObject.semanticSchemaFileNames)) {
+    validationOptionsObject.semanticSchemaFileNames =
+      validationOptionsObject.semanticSchemaFileNames.map((p: string) =>
+        path.isAbsolute(p) ? p : path.resolve(baseDir, p)
+      );
+  }
+
   const validationOptions = ValidationOptions.fromJson(validationOptionsObject);
   return validationOptions;
 }


### PR DESCRIPTION
When including a options file the URIs in the `semanticSchemaFileNames` array gets resolved in relation to current working directory.

The expected behavior would be to resolve these URIs relative the options file from where they are read.
